### PR TITLE
feat(perf): issue-117 phase 1/2 async db + workout critical path

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import './global.css';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -23,13 +24,21 @@ function ThemedStatusBar(): React.JSX.Element {
 
 export default function App(): React.JSX.Element {
   const perfLabEnabled = isPerfLabEnabled();
+  const bootstrapFallback = (
+    <View className="flex-1 items-center justify-center bg-background">
+      <ActivityIndicator size="large" />
+      <Text className="mt-4 font-body text-foreground">
+        Preparing your data
+      </Text>
+    </View>
+  );
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <ThemeProvider>
           <GluestackUIProvider>
-            <DatabaseProvider>
+            <DatabaseProvider fallback={bootstrapFallback}>
               <ThemedStatusBar />
               {perfLabEnabled ? <PerfLabScreen /> : <RootNavigator />}
               <WorkoutTimerNotificationCoordinator />

--- a/src/core/database/__tests__/migrations.test.ts
+++ b/src/core/database/__tests__/migrations.test.ts
@@ -4,10 +4,10 @@ import { prepareDatabase } from '../migrations';
 import { SCHEMA_VERSION } from '../schema';
 
 interface MockDatabase extends Partial<SQLiteDatabase> {
-  execSync: jest.Mock;
-  getAllSync: jest.Mock;
-  getFirstSync: jest.Mock;
-  withTransactionSync: jest.Mock;
+  execAsync: jest.Mock;
+  getAllAsync: jest.Mock;
+  getFirstAsync: jest.Mock;
+  withTransactionAsync: jest.Mock;
 }
 
 function createMigrationDbMock({
@@ -28,13 +28,13 @@ function createMigrationDbMock({
   let userVersion = version;
 
   const db: MockDatabase = {
-    execSync: jest.fn((sql: string) => {
+    execAsync: jest.fn(async (sql: string) => {
       const match = sql.match(/PRAGMA user_version = (\d+)/);
       if (match) {
         userVersion = Number(match[1]);
       }
     }),
-    getAllSync: jest.fn((sql: string) => {
+    getAllAsync: jest.fn(async (sql: string) => {
       const match = /^PRAGMA table_info\((.+)\)$/.exec(sql);
       if (match) {
         const tableName = match[1];
@@ -43,7 +43,7 @@ function createMigrationDbMock({
 
       return [];
     }),
-    getFirstSync: jest.fn((sql: string, params?: unknown[]) => {
+    getFirstAsync: jest.fn(async (sql: string, params?: unknown[]) => {
       if (sql === 'PRAGMA user_version') {
         return { user_version: userVersion };
       }
@@ -55,7 +55,7 @@ function createMigrationDbMock({
 
       return null;
     }),
-    withTransactionSync: jest.fn((fn: () => void) => fn()),
+    withTransactionAsync: jest.fn(async (fn: () => Promise<void>) => fn()),
   };
 
   return db;
@@ -73,43 +73,43 @@ describe('prepareDatabase', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('creates the latest schema for a fresh install and sets the current version', () => {
+  it('creates the latest schema for a fresh install and sets the current version', async () => {
     const db = createMigrationDbMock({
       version: 0,
       tableNames: [],
     });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION);
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       expect.stringContaining('CREATE TABLE IF NOT EXISTS body_weight_entries'),
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       `PRAGMA user_version = ${SCHEMA_VERSION}`,
     );
-    expect(db.withTransactionSync).not.toHaveBeenCalled();
+    expect(db.withTransactionAsync).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
-  it('migrates a version 2 database forward without destructive resets', () => {
+  it('migrates a version 2 database forward without destructive resets', async () => {
     const db = createMigrationDbMock({ version: 2 });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION);
-    expect(db.execSync).not.toHaveBeenCalledWith(
+    expect(db.execAsync).not.toHaveBeenCalledWith(
       expect.stringContaining('DROP TABLE'),
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       `PRAGMA user_version = ${SCHEMA_VERSION}`,
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       expect.stringContaining('CREATE TABLE IF NOT EXISTS body_weight_entries'),
     );
   });
 
-  it('patches legacy unversioned workout sessions before running newer migrations', () => {
+  it('patches legacy unversioned workout sessions before running newer migrations', async () => {
     const db = createMigrationDbMock({
       version: 0,
       tableNames: ['workout_sessions'],
@@ -120,19 +120,19 @@ describe('prepareDatabase', () => {
       },
     });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION);
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       'ALTER TABLE workout_sessions ADD COLUMN schedule_id TEXT;',
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       'ALTER TABLE workout_sessions ADD COLUMN snapshot_name TEXT;',
     );
-    expect(db.withTransactionSync).toHaveBeenCalled();
+    expect(db.withTransactionAsync).toHaveBeenCalled();
   });
 
-  it('adds phase-2 exercise metadata columns and user profile support for version 4 databases', () => {
+  it('adds phase-2 exercise metadata columns and user profile support for version 4 databases', async () => {
     const db = createMigrationDbMock({
       version: 4,
       tableNames: ['exercises', 'workout_sets'],
@@ -143,35 +143,35 @@ describe('prepareDatabase', () => {
       },
     });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION);
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       'ALTER TABLE exercises ADD COLUMN how_to TEXT;',
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       'ALTER TABLE exercises ADD COLUMN equipment TEXT;',
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       expect.stringContaining('CREATE TABLE IF NOT EXISTS user_profile'),
     );
   });
 
-  it('returns early on a newer schema version without applying DDL', () => {
+  it('returns early on a newer schema version without applying DDL', async () => {
     const db = createMigrationDbMock({
       version: SCHEMA_VERSION + 1,
       tableNames: ['workout_sessions', 'workout_sets'],
     });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION + 1);
-    expect(db.execSync).not.toHaveBeenCalledWith(
+    expect(db.execAsync).not.toHaveBeenCalledWith(
       expect.stringContaining('CREATE TABLE IF NOT EXISTS'),
     );
   });
 
-  it('adds routine and schedule archive columns for version 6 databases', () => {
+  it('adds routine and schedule archive columns for version 6 databases', async () => {
     const db = createMigrationDbMock({
       version: 6,
       tableNames: ['routines', 'schedules'],
@@ -184,18 +184,18 @@ describe('prepareDatabase', () => {
       },
     });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION);
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       'ALTER TABLE routines ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;',
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       'ALTER TABLE schedules ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;',
     );
   });
 
-  it('adds ordered-query indexes for version 10 databases', () => {
+  it('adds ordered-query indexes for version 10 databases', async () => {
     const db = createMigrationDbMock({
       version: 10,
       tableNames: [
@@ -240,20 +240,20 @@ describe('prepareDatabase', () => {
       },
     });
 
-    const finalVersion = prepareDatabase(db as SQLiteDatabase);
+    const finalVersion = await prepareDatabase(db as SQLiteDatabase);
 
     expect(finalVersion).toBe(SCHEMA_VERSION);
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       expect.stringContaining(
         'CREATE INDEX IF NOT EXISTS idx_schedule_entries_schedule_position',
       ),
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       expect.stringContaining(
         'CREATE INDEX IF NOT EXISTS idx_routine_exercises_routine_position',
       ),
     );
-    expect(db.execSync).toHaveBeenCalledWith(
+    expect(db.execAsync).toHaveBeenCalledWith(
       expect.stringContaining(
         'CREATE INDEX IF NOT EXISTS idx_workout_sessions_end_time_start_time',
       ),

--- a/src/core/database/__tests__/seed-development.test.ts
+++ b/src/core/database/__tests__/seed-development.test.ts
@@ -17,9 +17,9 @@ interface TableRow {
 }
 
 interface DevelopmentSeedDbMock extends Partial<SQLiteDatabase> {
-  getAllSync: jest.Mock;
-  runSync: jest.Mock;
-  withTransactionSync: jest.Mock;
+  getAllAsync: jest.Mock;
+  runAsync: jest.Mock;
+  withTransactionAsync: jest.Mock;
 }
 
 function createDevelopmentSeedDbMock(): DevelopmentSeedDbMock {
@@ -57,7 +57,7 @@ function createDevelopmentSeedDbMock(): DevelopmentSeedDbMock {
   }
 
   return {
-    getAllSync: jest.fn((sql: string, params?: unknown[]) => {
+    getAllAsync: jest.fn(async (sql: string, params?: unknown[]) => {
       if (sql.startsWith('SELECT id, name FROM exercises WHERE name IN')) {
         const names = (params ?? []) as string[];
         return names
@@ -70,7 +70,7 @@ function createDevelopmentSeedDbMock(): DevelopmentSeedDbMock {
 
       return [];
     }),
-    runSync: jest.fn((sql: string, params?: unknown[]) => {
+    runAsync: jest.fn(async (sql: string, params?: unknown[]) => {
       const values = (params ?? []) as unknown[];
 
       if (sql.startsWith('INSERT OR REPLACE INTO routines')) {
@@ -140,7 +140,7 @@ function createDevelopmentSeedDbMock(): DevelopmentSeedDbMock {
         });
       }
     }),
-    withTransactionSync: jest.fn((fn: () => void) => fn()),
+    withTransactionAsync: jest.fn(async (fn: () => Promise<void>) => fn()),
   };
 }
 
@@ -149,31 +149,31 @@ describe('seedDevelopmentDatabase', () => {
     jest.clearAllMocks();
   });
 
-  it('seeds a repeatable development dataset using the current exercise ids', () => {
+  it('seeds a repeatable development dataset using the current exercise ids', async () => {
     const db = createDevelopmentSeedDbMock();
 
-    seedDevelopmentDatabase(db as SQLiteDatabase);
-    seedDevelopmentDatabase(db as SQLiteDatabase);
+    await seedDevelopmentDatabase(db as SQLiteDatabase);
+    await seedDevelopmentDatabase(db as SQLiteDatabase);
 
     expect(mockSeedDefaultExercises).toHaveBeenCalledTimes(2);
-    expect(db.withTransactionSync).toHaveBeenCalledTimes(2);
+    expect(db.withTransactionAsync).toHaveBeenCalledTimes(2);
 
-    const routines = db.runSync.mock.calls.filter(([sql]) =>
+    const routines = db.runAsync.mock.calls.filter(([sql]) =>
       String(sql).startsWith('INSERT OR REPLACE INTO routines'),
     );
-    const schedules = db.runSync.mock.calls.filter(([sql]) =>
+    const schedules = db.runAsync.mock.calls.filter(([sql]) =>
       String(sql).startsWith('INSERT OR REPLACE INTO schedules'),
     );
-    const workoutSessions = db.runSync.mock.calls.filter(([sql]) =>
+    const workoutSessions = db.runAsync.mock.calls.filter(([sql]) =>
       String(sql).startsWith('INSERT OR REPLACE INTO workout_sessions'),
     );
-    const workoutSets = db.runSync.mock.calls.filter(([sql]) =>
+    const workoutSets = db.runAsync.mock.calls.filter(([sql]) =>
       String(sql).startsWith('INSERT OR REPLACE INTO workout_sets'),
     );
-    const bodyWeightEntries = db.runSync.mock.calls.filter(([sql]) =>
+    const bodyWeightEntries = db.runAsync.mock.calls.filter(([sql]) =>
       String(sql).startsWith('INSERT OR REPLACE INTO body_weight_entries'),
     );
-    const userProfile = db.runSync.mock.calls.filter(([sql]) =>
+    const userProfile = db.runAsync.mock.calls.filter(([sql]) =>
       String(sql).startsWith('INSERT OR REPLACE INTO user_profile'),
     );
 
@@ -194,14 +194,14 @@ describe('seedDevelopmentDatabase', () => {
     expect(userProfile).toHaveLength(2);
   });
 
-  it('seeds the default exercise catalog before resolving required exercise ids', () => {
+  it('seeds the default exercise catalog before resolving required exercise ids', async () => {
     const db = createDevelopmentSeedDbMock();
 
-    seedDevelopmentDatabase(db as SQLiteDatabase);
+    await seedDevelopmentDatabase(db as SQLiteDatabase);
 
     expect(mockSeedDefaultExercises).toHaveBeenCalledWith(db);
     expect(mockSeedDefaultExercises.mock.invocationCallOrder[0]).toBeLessThan(
-      db.getAllSync.mock.invocationCallOrder[0],
+      db.getAllAsync.mock.invocationCallOrder[0],
     );
   });
 

--- a/src/core/database/__tests__/seed-exercises.test.ts
+++ b/src/core/database/__tests__/seed-exercises.test.ts
@@ -4,9 +4,9 @@ import defaultExercises from '../seed-data/default-exercises.json';
 import { seedDefaultExercises } from '../seed-exercises';
 
 interface SeedExercisesDbMock extends Partial<SQLiteDatabase> {
-  getAllSync: jest.Mock;
-  runSync: jest.Mock;
-  withTransactionSync: jest.Mock;
+  getAllAsync: jest.Mock;
+  runAsync: jest.Mock;
+  withTransactionAsync: jest.Mock;
 }
 
 interface SeedExerciseRow {
@@ -35,7 +35,7 @@ function createSeedExercisesDbMock(
   );
 
   return {
-    getAllSync: jest.fn((sql: string, params?: unknown[]) => {
+    getAllAsync: jest.fn(async (sql: string, params?: unknown[]) => {
       if (
         sql ===
         `SELECT id, name, how_to, equipment FROM exercises WHERE name IN (${defaultExerciseNames
@@ -51,7 +51,7 @@ function createSeedExercisesDbMock(
 
       return [];
     }),
-    runSync: jest.fn((sql: string, params?: unknown[]) => {
+    runAsync: jest.fn(async (sql: string, params?: unknown[]) => {
       if (
         sql ===
           'INSERT INTO exercises (id, name, muscle_group, how_to, equipment) VALUES (?, ?, ?, ?, ?)' &&
@@ -80,38 +80,38 @@ function createSeedExercisesDbMock(
         }
       }
     }),
-    withTransactionSync: jest.fn((fn: () => void) => fn()),
+    withTransactionAsync: jest.fn(async (fn: () => Promise<void>) => fn()),
   };
 }
 
 describe('seedDefaultExercises', () => {
-  it('inserts only missing exercises and becomes a no-op on repeat runs', () => {
+  it('inserts only missing exercises and becomes a no-op on repeat runs', async () => {
     const existingNames = [defaultExercises[0].name, defaultExercises[1].name];
     const db = createSeedExercisesDbMock(existingNames);
     const totalExercises = defaultExercises.length;
 
-    seedDefaultExercises(db as SQLiteDatabase);
+    await seedDefaultExercises(db as SQLiteDatabase);
 
-    expect(db.withTransactionSync).toHaveBeenCalledTimes(1);
-    expect(db.runSync).toHaveBeenCalledTimes(
+    expect(db.withTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(db.runAsync).toHaveBeenCalledTimes(
       totalExercises - existingNames.length,
     );
 
-    db.runSync.mockClear();
-    db.withTransactionSync.mockClear();
+    db.runAsync.mockClear();
+    db.withTransactionAsync.mockClear();
 
-    seedDefaultExercises(db as SQLiteDatabase);
+    await seedDefaultExercises(db as SQLiteDatabase);
 
-    expect(db.withTransactionSync).not.toHaveBeenCalled();
-    expect(db.runSync).not.toHaveBeenCalled();
+    expect(db.withTransactionAsync).not.toHaveBeenCalled();
+    expect(db.runAsync).not.toHaveBeenCalled();
   });
 
-  it('queries only the default catalog names instead of scanning all exercises', () => {
+  it('queries only the default catalog names instead of scanning all exercises', async () => {
     const db = createSeedExercisesDbMock([]);
 
-    seedDefaultExercises(db as SQLiteDatabase);
+    await seedDefaultExercises(db as SQLiteDatabase);
 
-    expect(db.getAllSync).toHaveBeenCalledWith(
+    expect(db.getAllAsync).toHaveBeenCalledWith(
       `SELECT id, name, how_to, equipment FROM exercises WHERE name IN (${defaultExercises
         .map(() => '?')
         .join(', ')})`,
@@ -119,12 +119,12 @@ describe('seedDefaultExercises', () => {
     );
   });
 
-  it('backfills metadata for existing default exercises after a schema upgrade', () => {
+  it('backfills metadata for existing default exercises after a schema upgrade', async () => {
     const db = createSeedExercisesDbMock(['Barbell Bench Press']);
 
-    seedDefaultExercises(db as SQLiteDatabase);
+    await seedDefaultExercises(db as SQLiteDatabase);
 
-    expect(db.runSync).toHaveBeenCalledWith(
+    expect(db.runAsync).toHaveBeenCalledWith(
       'UPDATE exercises SET how_to = COALESCE(how_to, ?), equipment = COALESCE(equipment, ?) WHERE id = ?',
       expect.arrayContaining(['Barbell and bench']),
     );

--- a/src/core/database/__tests__/test-utils.tsx
+++ b/src/core/database/__tests__/test-utils.tsx
@@ -13,10 +13,15 @@ import { DatabaseProvider } from '@core/database/provider';
 // Minimal interface matching only the methods our hooks use.
 export interface MockDb {
   getAllSync: jest.Mock;
+  getAllAsync: jest.Mock;
   getFirstSync: jest.Mock;
+  getFirstAsync: jest.Mock;
   runSync: jest.Mock;
+  runAsync: jest.Mock;
   execSync: jest.Mock;
+  execAsync: jest.Mock;
   withTransactionSync: jest.Mock;
+  withTransactionAsync: jest.Mock;
 }
 
 // ─── Factory ──────────────────────────────────────────────────────────────────
@@ -28,13 +33,24 @@ export interface MockDb {
  * transactions is exercised normally.
  */
 export function createMockDb(): MockDb {
-  return {
+  const db: MockDb = {
     getAllSync: jest.fn().mockReturnValue([]),
+    getAllAsync: jest.fn(async (...args: unknown[]) => db.getAllSync(...args)),
     getFirstSync: jest.fn().mockReturnValue(null),
+    getFirstAsync: jest.fn(async (...args: unknown[]) =>
+      db.getFirstSync(...args),
+    ),
     runSync: jest.fn(),
+    runAsync: jest.fn(async (...args: unknown[]) => db.runSync(...args)),
     execSync: jest.fn(),
+    execAsync: jest.fn(async (...args: unknown[]) => db.execSync(...args)),
     withTransactionSync: jest.fn().mockImplementation((fn: () => void) => fn()),
+    withTransactionAsync: jest
+      .fn()
+      .mockImplementation(async (fn: () => Promise<void>) => fn()),
   };
+
+  return db;
 }
 
 // ─── Test wrapper ─────────────────────────────────────────────────────────────

--- a/src/core/database/database.ts
+++ b/src/core/database/database.ts
@@ -20,6 +20,9 @@ export function getDatabase(): Promise<SQLiteDatabase> {
     return cachedDatabasePromise;
   }
 
-  cachedDatabasePromise = initDatabaseAsync();
+  cachedDatabasePromise = initDatabaseAsync().catch((error: unknown) => {
+    cachedDatabasePromise = null;
+    throw error;
+  });
   return cachedDatabasePromise;
 }

--- a/src/core/database/database.ts
+++ b/src/core/database/database.ts
@@ -1,4 +1,4 @@
-import { openDatabaseSync, type SQLiteDatabase } from 'expo-sqlite';
+import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
 
 import { prepareDatabase } from './migrations';
 
@@ -6,16 +6,20 @@ import { prepareDatabase } from './migrations';
  * Open (or create) the SQLite database and ensure all tables exist.
  *
  * expo-sqlite stores the file in the app's Documents directory automatically.
- * The synchronous API avoids the need for async initialisation at startup.
  */
-export function initDatabase(): SQLiteDatabase {
-  const db = openDatabaseSync('trainer.db');
-  prepareDatabase(db);
+export async function initDatabaseAsync(): Promise<SQLiteDatabase> {
+  const db = await openDatabaseAsync('trainer.db');
+  await prepareDatabase(db);
   return db;
 }
 
-/**
- * Singleton database instance.
- * Import via `@core/database` — never import this file directly in components.
- */
-export const database: SQLiteDatabase = initDatabase();
+let cachedDatabasePromise: Promise<SQLiteDatabase> | null = null;
+
+export function getDatabase(): Promise<SQLiteDatabase> {
+  if (cachedDatabasePromise !== null) {
+    return cachedDatabasePromise;
+  }
+
+  cachedDatabasePromise = initDatabaseAsync();
+  return cachedDatabasePromise;
+}

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -5,7 +5,7 @@
  * of the app via a React context / custom hook.
  * Never import this module directly inside a React component — use useDatabase().
  */
-export { database } from './database';
+export { getDatabase, initDatabaseAsync } from './database';
 export type {
   BodyWeightEntry,
   Exercise,
@@ -19,7 +19,7 @@ export type {
   WorkoutSessionExercise,
   WorkoutSet,
 } from './types';
-export { DatabaseProvider, useDatabase } from './provider';
+export { DatabaseProvider, useDatabase, useOptionalDatabase } from './provider';
 export { seedDevelopmentDatabase } from './seed-development';
 export { seedDefaultExercises } from './seed-exercises';
 export { generateId } from './utils';

--- a/src/core/database/migrations.ts
+++ b/src/core/database/migrations.ts
@@ -24,29 +24,29 @@ interface LegacyRoutineExerciseRow {
 interface Migration {
   version: number;
   description: string;
-  up: (db: SQLiteDatabase) => void;
+  up: (db: SQLiteDatabase) => Promise<void>;
 }
 
 const migrations: Migration[] = [
   {
     version: 1,
     description: 'Adopt explicit schema versioning for existing installs.',
-    up: () => {
+    up: async () => {
       // Version 1 matched the bootstrap-created base schema.
     },
   },
   {
     version: 2,
     description: 'Advance the schema version without changing table layout.',
-    up: () => {
+    up: async () => {
       // Version 2 only introduced the user_version pragma.
     },
   },
   {
     version: 3,
     description: 'Add persisted body-weight entries for offline tracking.',
-    up: (db) => {
-      db.execSync(`
+    up: async (db) => {
+      await db.execAsync(`
         CREATE TABLE IF NOT EXISTS body_weight_entries (
           id        TEXT PRIMARY KEY NOT NULL,
           weight    REAL NOT NULL,
@@ -63,13 +63,17 @@ const migrations: Migration[] = [
   {
     version: 4,
     description: 'Persist workout set targets inside session snapshots.',
-    up: (db) => {
-      if (!columnExists(db, 'workout_sets', 'target_sets')) {
-        db.execSync('ALTER TABLE workout_sets ADD COLUMN target_sets INTEGER;');
+    up: async (db) => {
+      if (!(await columnExists(db, 'workout_sets', 'target_sets'))) {
+        await db.execAsync(
+          'ALTER TABLE workout_sets ADD COLUMN target_sets INTEGER;',
+        );
       }
 
-      if (!columnExists(db, 'workout_sets', 'target_reps')) {
-        db.execSync('ALTER TABLE workout_sets ADD COLUMN target_reps INTEGER;');
+      if (!(await columnExists(db, 'workout_sets', 'target_reps'))) {
+        await db.execAsync(
+          'ALTER TABLE workout_sets ADD COLUMN target_reps INTEGER;',
+        );
       }
     },
   },
@@ -77,16 +81,16 @@ const migrations: Migration[] = [
     version: 5,
     description:
       'Add user profile settings and richer exercise metadata for phase 2.',
-    up: (db) => {
-      if (!columnExists(db, 'exercises', 'how_to')) {
-        db.execSync('ALTER TABLE exercises ADD COLUMN how_to TEXT;');
+    up: async (db) => {
+      if (!(await columnExists(db, 'exercises', 'how_to'))) {
+        await db.execAsync('ALTER TABLE exercises ADD COLUMN how_to TEXT;');
       }
 
-      if (!columnExists(db, 'exercises', 'equipment')) {
-        db.execSync('ALTER TABLE exercises ADD COLUMN equipment TEXT;');
+      if (!(await columnExists(db, 'exercises', 'equipment'))) {
+        await db.execAsync('ALTER TABLE exercises ADD COLUMN equipment TEXT;');
       }
 
-      db.execSync(`
+      await db.execAsync(`
         CREATE TABLE IF NOT EXISTS user_profile (
           id                    TEXT PRIMARY KEY NOT NULL,
           display_name          TEXT,
@@ -101,9 +105,9 @@ const migrations: Migration[] = [
     version: 6,
     description:
       'Add soft deletion for exercises to preserve historical workout data.',
-    up: (db) => {
-      if (!columnExists(db, 'exercises', 'is_deleted')) {
-        db.execSync(
+    up: async (db) => {
+      if (!(await columnExists(db, 'exercises', 'is_deleted'))) {
+        await db.execAsync(
           'ALTER TABLE exercises ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;',
         );
       }
@@ -112,15 +116,15 @@ const migrations: Migration[] = [
   {
     version: 7,
     description: 'Add soft deletion for routines and schedules.',
-    up: (db) => {
-      if (!columnExists(db, 'routines', 'is_deleted')) {
-        db.execSync(
+    up: async (db) => {
+      if (!(await columnExists(db, 'routines', 'is_deleted'))) {
+        await db.execAsync(
           'ALTER TABLE routines ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;',
         );
       }
 
-      if (!columnExists(db, 'schedules', 'is_deleted')) {
-        db.execSync(
+      if (!(await columnExists(db, 'schedules', 'is_deleted'))) {
+        await db.execAsync(
           'ALTER TABLE schedules ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;',
         );
       }
@@ -130,15 +134,15 @@ const migrations: Migration[] = [
     version: 8,
     description:
       'Persist post-workout effort and fatigue scores on workout sessions.',
-    up: (db) => {
-      if (!columnExists(db, 'workout_sessions', 'effort_level')) {
-        db.execSync(
+    up: async (db) => {
+      if (!(await columnExists(db, 'workout_sessions', 'effort_level'))) {
+        await db.execAsync(
           'ALTER TABLE workout_sessions ADD COLUMN effort_level INTEGER;',
         );
       }
 
-      if (!columnExists(db, 'workout_sessions', 'fatigue_level')) {
-        db.execSync(
+      if (!(await columnExists(db, 'workout_sessions', 'fatigue_level'))) {
+        await db.execAsync(
           'ALTER TABLE workout_sessions ADD COLUMN fatigue_level INTEGER;',
         );
       }
@@ -148,8 +152,8 @@ const migrations: Migration[] = [
     version: 9,
     description:
       'Add routine template sets, session exercise snapshots, explicit set positions, and template-apply tracking.',
-    up: (db) => {
-      db.execSync(`
+    up: async (db) => {
+      await db.execAsync(`
         CREATE TABLE IF NOT EXISTS routine_exercise_sets (
           id                  TEXT PRIMARY KEY NOT NULL,
           routine_exercise_id TEXT NOT NULL,
@@ -173,38 +177,45 @@ const migrations: Migration[] = [
           ON workout_session_exercises (session_id);
       `);
 
-      if (!columnExists(db, 'routine_exercises', 'rest_seconds')) {
-        db.execSync(
+      if (!(await columnExists(db, 'routine_exercises', 'rest_seconds'))) {
+        await db.execAsync(
           'ALTER TABLE routine_exercises ADD COLUMN rest_seconds INTEGER;',
         );
       }
 
-      if (!columnExists(db, 'workout_sets', 'position')) {
-        db.execSync('ALTER TABLE workout_sets ADD COLUMN position INTEGER;');
+      if (!(await columnExists(db, 'workout_sets', 'position'))) {
+        await db.execAsync(
+          'ALTER TABLE workout_sets ADD COLUMN position INTEGER;',
+        );
       }
 
-      if (!columnExists(db, 'workout_sessions', 'template_applied_at')) {
-        db.execSync(
+      if (
+        !(await columnExists(db, 'workout_sessions', 'template_applied_at'))
+      ) {
+        await db.execAsync(
           'ALTER TABLE workout_sessions ADD COLUMN template_applied_at INTEGER;',
         );
       }
 
-      const routineExerciseSetsCount = db.getFirstSync<{ count: number }>(
-        'SELECT COUNT(*) AS count FROM routine_exercise_sets',
+      const routineExerciseSetsCount = (
+        await db.getFirstAsync<{ count: number }>(
+          'SELECT COUNT(*) AS count FROM routine_exercise_sets',
+        )
       )?.count;
 
       if ((routineExerciseSetsCount ?? 0) === 0) {
-        const legacyRoutineExercises = db.getAllSync<LegacyRoutineExerciseRow>(
-          `SELECT id, target_reps, target_sets
-           FROM routine_exercises
-           ORDER BY position ASC`,
-        );
+        const legacyRoutineExercises =
+          await db.getAllAsync<LegacyRoutineExerciseRow>(
+            `SELECT id, target_reps, target_sets
+             FROM routine_exercises
+             ORDER BY position ASC`,
+          );
 
         for (const routineExercise of legacyRoutineExercises) {
           const setCount = Math.max(1, routineExercise.target_sets);
 
           for (let index = 0; index < setCount; index += 1) {
-            db.runSync(
+            await db.runAsync(
               `INSERT INTO routine_exercise_sets (
                 id,
                 routine_exercise_id,
@@ -229,80 +240,94 @@ const migrations: Migration[] = [
     version: 10,
     description:
       'Add deterministic intelligence columns for set roles, rep ranges, exercise capability flags, and typed goals.',
-    up: (db) => {
-      if (!columnExists(db, 'exercises', 'strength_estimation_mode')) {
-        db.execSync(
+    up: async (db) => {
+      if (!(await columnExists(db, 'exercises', 'strength_estimation_mode'))) {
+        await db.execAsync(
           "ALTER TABLE exercises ADD COLUMN strength_estimation_mode TEXT NOT NULL DEFAULT 'limited';",
         );
       }
 
-      if (!columnExists(db, 'routine_exercises', 'progression_policy')) {
-        db.execSync(
+      if (
+        !(await columnExists(db, 'routine_exercises', 'progression_policy'))
+      ) {
+        await db.execAsync(
           "ALTER TABLE routine_exercises ADD COLUMN progression_policy TEXT NOT NULL DEFAULT 'double_progression';",
         );
       }
 
-      if (!columnExists(db, 'routine_exercises', 'target_rir')) {
-        db.execSync(
+      if (!(await columnExists(db, 'routine_exercises', 'target_rir'))) {
+        await db.execAsync(
           'ALTER TABLE routine_exercises ADD COLUMN target_rir REAL;',
         );
       }
 
-      if (!columnExists(db, 'routine_exercise_sets', 'target_reps_min')) {
-        db.execSync(
+      if (
+        !(await columnExists(db, 'routine_exercise_sets', 'target_reps_min'))
+      ) {
+        await db.execAsync(
           'ALTER TABLE routine_exercise_sets ADD COLUMN target_reps_min INTEGER;',
         );
       }
 
-      if (!columnExists(db, 'routine_exercise_sets', 'target_reps_max')) {
-        db.execSync(
+      if (
+        !(await columnExists(db, 'routine_exercise_sets', 'target_reps_max'))
+      ) {
+        await db.execAsync(
           'ALTER TABLE routine_exercise_sets ADD COLUMN target_reps_max INTEGER;',
         );
       }
 
-      if (!columnExists(db, 'routine_exercise_sets', 'set_role')) {
-        db.execSync(
+      if (!(await columnExists(db, 'routine_exercise_sets', 'set_role'))) {
+        await db.execAsync(
           "ALTER TABLE routine_exercise_sets ADD COLUMN set_role TEXT NOT NULL DEFAULT 'work';",
         );
       }
 
       if (
-        !columnExists(db, 'workout_session_exercises', 'progression_policy')
+        !(await columnExists(
+          db,
+          'workout_session_exercises',
+          'progression_policy',
+        ))
       ) {
-        db.execSync(
+        await db.execAsync(
           "ALTER TABLE workout_session_exercises ADD COLUMN progression_policy TEXT NOT NULL DEFAULT 'double_progression';",
         );
       }
 
-      if (!columnExists(db, 'workout_session_exercises', 'target_rir')) {
-        db.execSync(
+      if (
+        !(await columnExists(db, 'workout_session_exercises', 'target_rir'))
+      ) {
+        await db.execAsync(
           'ALTER TABLE workout_session_exercises ADD COLUMN target_rir REAL;',
         );
       }
 
-      if (!columnExists(db, 'workout_sets', 'target_reps_min')) {
-        db.execSync(
+      if (!(await columnExists(db, 'workout_sets', 'target_reps_min'))) {
+        await db.execAsync(
           'ALTER TABLE workout_sets ADD COLUMN target_reps_min INTEGER;',
         );
       }
 
-      if (!columnExists(db, 'workout_sets', 'target_reps_max')) {
-        db.execSync(
+      if (!(await columnExists(db, 'workout_sets', 'target_reps_max'))) {
+        await db.execAsync(
           'ALTER TABLE workout_sets ADD COLUMN target_reps_max INTEGER;',
         );
       }
 
-      if (!columnExists(db, 'workout_sets', 'actual_rir')) {
-        db.execSync('ALTER TABLE workout_sets ADD COLUMN actual_rir REAL;');
+      if (!(await columnExists(db, 'workout_sets', 'actual_rir'))) {
+        await db.execAsync(
+          'ALTER TABLE workout_sets ADD COLUMN actual_rir REAL;',
+        );
       }
 
-      if (!columnExists(db, 'workout_sets', 'set_role')) {
-        db.execSync(
+      if (!(await columnExists(db, 'workout_sets', 'set_role'))) {
+        await db.execAsync(
           "ALTER TABLE workout_sets ADD COLUMN set_role TEXT NOT NULL DEFAULT 'work';",
         );
       }
 
-      db.execSync(`
+      await db.execAsync(`
         CREATE TABLE IF NOT EXISTS training_goals (
           id TEXT PRIMARY KEY NOT NULL,
           goal_type TEXT NOT NULL,
@@ -324,13 +349,13 @@ const migrations: Migration[] = [
           ON training_goals (status);
       `);
 
-      db.execSync(`
+      await db.execAsync(`
         UPDATE routine_exercise_sets
         SET target_reps_min = COALESCE(target_reps_min, target_reps),
             target_reps_max = COALESCE(target_reps_max, target_reps)
       `);
 
-      db.execSync(`
+      await db.execAsync(`
         UPDATE workout_sets
         SET target_reps_min = COALESCE(target_reps_min, target_reps),
             target_reps_max = COALESCE(target_reps_max, target_reps)
@@ -341,8 +366,8 @@ const migrations: Migration[] = [
     version: 11,
     description:
       'Add ordered-query indexes for schedules, routines, workout sessions, and session snapshots.',
-    up: (db) => {
-      db.execSync(`
+    up: async (db) => {
+      await db.execAsync(`
         CREATE INDEX IF NOT EXISTS idx_schedule_entries_schedule_position
           ON schedule_entries (schedule_id, position);
 
@@ -365,48 +390,55 @@ const migrations: Migration[] = [
   },
 ];
 
-function setUserVersion(db: SQLiteDatabase, version: number): void {
-  db.execSync(`PRAGMA user_version = ${version}`);
+async function setUserVersion(
+  db: SQLiteDatabase,
+  version: number,
+): Promise<void> {
+  await db.execAsync(`PRAGMA user_version = ${version}`);
 }
 
-function tableExists(db: SQLiteDatabase, tableName: string): boolean {
-  const row = db.getFirstSync<SqliteMasterRow>(
+async function tableExists(
+  db: SQLiteDatabase,
+  tableName: string,
+): Promise<boolean> {
+  const row = await db.getFirstAsync<SqliteMasterRow>(
     "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
     [tableName],
   );
   return row?.name === tableName;
 }
 
-function columnExists(
+async function columnExists(
   db: SQLiteDatabase,
   tableName: string,
   columnName: string,
-): boolean {
-  const columns = db.getAllSync<TableInfoRow>(
+): Promise<boolean> {
+  const columns = await db.getAllAsync<TableInfoRow>(
     `PRAGMA table_info(${tableName})`,
   );
   return columns.some((column) => column.name === columnName);
 }
 
-export function getUserVersion(db: SQLiteDatabase): number {
+export async function getUserVersion(db: SQLiteDatabase): Promise<number> {
   return (
-    db.getFirstSync<UserVersionRow>('PRAGMA user_version')?.user_version ?? 0
+    (await db.getFirstAsync<UserVersionRow>('PRAGMA user_version'))
+      ?.user_version ?? 0
   );
 }
 
-function hasTrainerTables(db: SQLiteDatabase): boolean {
+async function hasTrainerTables(db: SQLiteDatabase): Promise<boolean> {
   return (
-    tableExists(db, 'exercises') ||
-    tableExists(db, 'routines') ||
-    tableExists(db, 'schedules') ||
-    tableExists(db, 'workout_sessions') ||
-    tableExists(db, 'workout_sets') ||
-    tableExists(db, 'body_weight_entries')
+    (await tableExists(db, 'exercises')) ||
+    (await tableExists(db, 'routines')) ||
+    (await tableExists(db, 'schedules')) ||
+    (await tableExists(db, 'workout_sessions')) ||
+    (await tableExists(db, 'workout_sets')) ||
+    (await tableExists(db, 'body_weight_entries'))
   );
 }
 
-export function prepareDatabase(db: SQLiteDatabase): number {
-  const currentVersion = getUserVersion(db);
+export async function prepareDatabase(db: SQLiteDatabase): Promise<number> {
+  const currentVersion = await getUserVersion(db);
 
   if (currentVersion > SCHEMA_VERSION) {
     console.warn(
@@ -415,29 +447,31 @@ export function prepareDatabase(db: SQLiteDatabase): number {
     return currentVersion;
   }
 
-  if (currentVersion === 0 && !hasTrainerTables(db)) {
-    db.execSync(CREATE_TABLES_SQL);
-    setUserVersion(db, SCHEMA_VERSION);
+  if (currentVersion === 0 && !(await hasTrainerTables(db))) {
+    await db.execAsync(CREATE_TABLES_SQL);
+    await setUserVersion(db, SCHEMA_VERSION);
     return SCHEMA_VERSION;
   }
 
-  db.execSync(CREATE_TABLES_SQL);
+  await db.execAsync(CREATE_TABLES_SQL);
 
   if (
     currentVersion === 0 &&
-    tableExists(db, 'workout_sessions') &&
-    !columnExists(db, 'workout_sessions', 'schedule_id')
+    (await tableExists(db, 'workout_sessions')) &&
+    !(await columnExists(db, 'workout_sessions', 'schedule_id'))
   ) {
-    db.withTransactionSync(() => {
-      db.execSync('ALTER TABLE workout_sessions ADD COLUMN schedule_id TEXT;');
-      db.execSync(
+    await db.withTransactionAsync(async () => {
+      await db.execAsync(
+        'ALTER TABLE workout_sessions ADD COLUMN schedule_id TEXT;',
+      );
+      await db.execAsync(
         'ALTER TABLE workout_sessions ADD COLUMN snapshot_name TEXT;',
       );
-      setUserVersion(db, 2);
+      await setUserVersion(db, 2);
     });
   }
 
-  let migratedVersion = getUserVersion(db);
+  let migratedVersion = await getUserVersion(db);
 
   for (const migration of migrations) {
     if (migration.version <= migratedVersion) {
@@ -448,9 +482,9 @@ export function prepareDatabase(db: SQLiteDatabase): number {
       `[Database] Migrating schema from version ${migratedVersion} to ${migration.version}: ${migration.description}`,
     );
 
-    db.withTransactionSync(() => {
-      migration.up(db);
-      setUserVersion(db, migration.version);
+    await db.withTransactionAsync(async () => {
+      await migration.up(db);
+      await setUserVersion(db, migration.version);
     });
 
     migratedVersion = migration.version;

--- a/src/core/database/provider.tsx
+++ b/src/core/database/provider.tsx
@@ -1,7 +1,8 @@
 import type { SQLiteDatabase } from 'expo-sqlite';
 import React, { createContext, useContext, useEffect } from 'react';
+import { useState } from 'react';
 
-import { database } from './database';
+import { getDatabase } from './database';
 import { seedDevelopmentDatabase } from './seed-development';
 import { seedDefaultExercises } from './seed-exercises';
 
@@ -13,6 +14,8 @@ interface DatabaseProviderProps {
   children: React.ReactNode;
   /** Override the database instance (useful for testing). */
   db?: SQLiteDatabase;
+  /** Optional fallback rendered while async bootstrap is in progress. */
+  fallback?: React.ReactNode;
 }
 
 /**
@@ -23,30 +26,72 @@ interface DatabaseProviderProps {
  */
 export function DatabaseProvider({
   children,
-  db = database,
+  db,
+  fallback = null,
 }: DatabaseProviderProps): React.JSX.Element {
+  const [resolvedDatabase, setResolvedDatabase] =
+    useState<SQLiteDatabase | null>(db ?? null);
+  const [isReady, setIsReady] = useState<boolean>(db !== undefined);
+
   useEffect(() => {
+    let isCancelled = false;
+
+    if (db !== undefined) {
+      setResolvedDatabase(db);
+      setIsReady(true);
+      return () => {
+        isCancelled = true;
+      };
+    }
+
     const shouldSeedDevelopmentData =
       __DEV__ && process.env.EXPO_PUBLIC_DEV_SEED === '1';
 
-    try {
-      if (shouldSeedDevelopmentData) {
-        seedDevelopmentDatabase(db);
-      } else {
-        seedDefaultExercises(db);
+    async function bootstrapDatabase(): Promise<void> {
+      const targetDb = await getDatabase();
+
+      if (isCancelled) {
+        return;
       }
-    } catch (error) {
-      console.error(
-        shouldSeedDevelopmentData
-          ? '[Seed] Failed to seed development data:'
-          : '[Seed] Failed to seed default exercises:',
-        error,
-      );
+
+      try {
+        if (shouldSeedDevelopmentData) {
+          await seedDevelopmentDatabase(targetDb);
+        } else {
+          await seedDefaultExercises(targetDb);
+        }
+      } catch (error) {
+        console.error(
+          shouldSeedDevelopmentData
+            ? '[Seed] Failed to seed development data:'
+            : '[Seed] Failed to seed default exercises:',
+          error,
+        );
+      }
+
+      if (!isCancelled) {
+        setResolvedDatabase(targetDb);
+        setIsReady(true);
+      }
     }
+
+    setIsReady(false);
+    setResolvedDatabase(null);
+    void bootstrapDatabase();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [db]);
 
+  if (!isReady || resolvedDatabase === null) {
+    return <>{fallback}</>;
+  }
+
   return (
-    <DatabaseContext.Provider value={db}>{children}</DatabaseContext.Provider>
+    <DatabaseContext.Provider value={resolvedDatabase}>
+      {children}
+    </DatabaseContext.Provider>
   );
 }
 

--- a/src/core/database/provider.tsx
+++ b/src/core/database/provider.tsx
@@ -6,6 +6,9 @@ import { getDatabase } from './database';
 import { seedDevelopmentDatabase } from './seed-development';
 import { seedDefaultExercises } from './seed-exercises';
 
+const BOOTSTRAP_MAX_ATTEMPTS = 3;
+const BOOTSTRAP_RETRY_DELAY_MS = 750;
+
 // ─── React Context ────────────────────────────────────────────────────────────
 
 const DatabaseContext = createContext<SQLiteDatabase | null>(null);
@@ -32,13 +35,17 @@ export function DatabaseProvider({
   const [resolvedDatabase, setResolvedDatabase] =
     useState<SQLiteDatabase | null>(db ?? null);
   const [isReady, setIsReady] = useState<boolean>(db !== undefined);
+  const [bootstrapError, setBootstrapError] = useState<Error | null>(null);
 
   useEffect(() => {
     let isCancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    let attemptCount = 0;
 
     if (db !== undefined) {
       setResolvedDatabase(db);
       setIsReady(true);
+      setBootstrapError(null);
       return () => {
         isCancelled = true;
       };
@@ -47,42 +54,82 @@ export function DatabaseProvider({
     const shouldSeedDevelopmentData =
       __DEV__ && process.env.EXPO_PUBLIC_DEV_SEED === '1';
 
-    async function bootstrapDatabase(): Promise<void> {
-      const targetDb = await getDatabase();
-
-      if (isCancelled) {
-        return;
+    function normalizeError(error: unknown): Error {
+      if (error instanceof Error) {
+        return error;
       }
 
+      return new Error(String(error));
+    }
+
+    async function bootstrapDatabase(): Promise<void> {
       try {
-        if (shouldSeedDevelopmentData) {
-          await seedDevelopmentDatabase(targetDb);
-        } else {
-          await seedDefaultExercises(targetDb);
+        attemptCount += 1;
+        const targetDb = await getDatabase();
+
+        if (isCancelled) {
+          return;
+        }
+
+        try {
+          if (shouldSeedDevelopmentData) {
+            await seedDevelopmentDatabase(targetDb);
+          } else {
+            await seedDefaultExercises(targetDb);
+          }
+        } catch (error) {
+          console.error(
+            shouldSeedDevelopmentData
+              ? '[Seed] Failed to seed development data:'
+              : '[Seed] Failed to seed default exercises:',
+            error,
+          );
+        }
+
+        if (!isCancelled) {
+          setResolvedDatabase(targetDb);
+          setIsReady(true);
+          setBootstrapError(null);
         }
       } catch (error) {
+        const normalizedError = normalizeError(error);
         console.error(
-          shouldSeedDevelopmentData
-            ? '[Seed] Failed to seed development data:'
-            : '[Seed] Failed to seed default exercises:',
-          error,
+          `[Database] Failed to initialize (attempt ${attemptCount}/${BOOTSTRAP_MAX_ATTEMPTS}):`,
+          normalizedError,
         );
-      }
 
-      if (!isCancelled) {
-        setResolvedDatabase(targetDb);
-        setIsReady(true);
+        if (isCancelled) {
+          return;
+        }
+
+        if (attemptCount >= BOOTSTRAP_MAX_ATTEMPTS) {
+          setBootstrapError(normalizedError);
+          return;
+        }
+
+        retryTimeout = setTimeout(() => {
+          retryTimeout = null;
+          void bootstrapDatabase();
+        }, BOOTSTRAP_RETRY_DELAY_MS);
       }
     }
 
     setIsReady(false);
     setResolvedDatabase(null);
+    setBootstrapError(null);
     void bootstrapDatabase();
 
     return () => {
       isCancelled = true;
+      if (retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+      }
     };
   }, [db]);
+
+  if (bootstrapError) {
+    throw bootstrapError;
+  }
 
   if (!isReady || resolvedDatabase === null) {
     return <>{fallback}</>;

--- a/src/core/database/seed-development.ts
+++ b/src/core/database/seed-development.ts
@@ -11,19 +11,21 @@ interface ExerciseNameRow {
 function resolveExerciseIds(
   db: SQLiteDatabase,
   exerciseNames: string[],
-): Map<string, string> {
+): Promise<Map<string, string>> {
   if (exerciseNames.length === 0) {
-    return new Map();
+    return Promise.resolve(new Map());
   }
 
-  const rows = db.getAllSync<ExerciseNameRow>(
-    `SELECT id, name FROM exercises WHERE name IN (${exerciseNames
-      .map(() => '?')
-      .join(', ')})`,
-    exerciseNames,
-  );
-
-  return new Map(rows.map((row: ExerciseNameRow) => [row.name, row.id]));
+  return db
+    .getAllAsync<ExerciseNameRow>(
+      `SELECT id, name FROM exercises WHERE name IN (${exerciseNames
+        .map(() => '?')
+        .join(', ')})`,
+      exerciseNames,
+    )
+    .then(
+      (rows) => new Map(rows.map((row: ExerciseNameRow) => [row.name, row.id])),
+    );
 }
 
 function requireExerciseId(
@@ -65,23 +67,25 @@ function collectRequiredExerciseNames(): string[] {
  * The seed is additive and idempotent for the fixed development records,
  * so it is safe to run on every app launch in development mode.
  */
-export function seedDevelopmentDatabase(db: SQLiteDatabase): void {
-  seedDefaultExercises(db);
+export async function seedDevelopmentDatabase(
+  db: SQLiteDatabase,
+): Promise<void> {
+  await seedDefaultExercises(db);
 
-  const exerciseIdsByName = resolveExerciseIds(
+  const exerciseIdsByName = await resolveExerciseIds(
     db,
     collectRequiredExerciseNames(),
   );
 
-  db.withTransactionSync(() => {
+  await db.withTransactionAsync(async () => {
     for (const routine of developmentSeedData.routines) {
-      db.runSync(
+      await db.runAsync(
         'INSERT OR REPLACE INTO routines (id, name, notes) VALUES (?, ?, ?)',
         [routine.id, routine.name, routine.notes],
       );
 
       for (const exercise of routine.exercises) {
-        db.runSync(
+        await db.runAsync(
           'INSERT OR REPLACE INTO routine_exercises (id, routine_id, exercise_id, position, target_sets, target_reps) VALUES (?, ?, ?, ?, ?, ?)',
           [
             exercise.id,
@@ -96,7 +100,7 @@ export function seedDevelopmentDatabase(db: SQLiteDatabase): void {
     }
 
     for (const schedule of developmentSeedData.schedules) {
-      db.runSync(
+      await db.runAsync(
         'INSERT OR REPLACE INTO schedules (id, name, is_active, current_position) VALUES (?, ?, ?, ?)',
         [
           schedule.id,
@@ -107,7 +111,7 @@ export function seedDevelopmentDatabase(db: SQLiteDatabase): void {
       );
 
       for (const entry of schedule.entries) {
-        db.runSync(
+        await db.runAsync(
           'INSERT OR REPLACE INTO schedule_entries (id, schedule_id, routine_id, position) VALUES (?, ?, ?, ?)',
           [entry.id, schedule.id, entry.routineId, entry.position],
         );
@@ -115,7 +119,7 @@ export function seedDevelopmentDatabase(db: SQLiteDatabase): void {
     }
 
     for (const session of developmentSeedData.workoutSessions) {
-      db.runSync(
+      await db.runAsync(
         'INSERT OR REPLACE INTO workout_sessions (id, routine_id, schedule_id, snapshot_name, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)',
         [
           session.id,
@@ -128,7 +132,7 @@ export function seedDevelopmentDatabase(db: SQLiteDatabase): void {
       );
 
       for (const set of session.sets) {
-        db.runSync(
+        await db.runAsync(
           'INSERT OR REPLACE INTO workout_sets (id, session_id, exercise_id, weight, reps, is_completed, target_sets, target_reps) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
           [
             set.id,
@@ -145,13 +149,13 @@ export function seedDevelopmentDatabase(db: SQLiteDatabase): void {
     }
 
     for (const entry of developmentSeedData.bodyWeightEntries) {
-      db.runSync(
+      await db.runAsync(
         'INSERT OR REPLACE INTO body_weight_entries (id, weight, unit, logged_at, notes) VALUES (?, ?, ?, ?, ?)',
         [entry.id, entry.weight, entry.unit, entry.loggedAt, entry.notes],
       );
     }
 
-    db.runSync(
+    await db.runAsync(
       'INSERT OR REPLACE INTO user_profile (id, display_name, preferred_weight_unit, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
       [
         developmentSeedData.userProfile.id,

--- a/src/core/database/seed-exercises.ts
+++ b/src/core/database/seed-exercises.ts
@@ -27,11 +27,11 @@ const defaultExercises: ExerciseSeedEntry[] = exerciseSeedData;
  *
  * @param db - The expo-sqlite `SQLiteDatabase` instance to seed.
  */
-export function seedDefaultExercises(db: SQLiteDatabase): void {
+export async function seedDefaultExercises(db: SQLiteDatabase): Promise<void> {
   const defaultExerciseNames = defaultExercises.map(
     (exercise: ExerciseSeedEntry) => exercise.name,
   );
-  const existingExercises = db.getAllSync<ExistingExerciseRow>(
+  const existingExercises = await db.getAllAsync<ExistingExerciseRow>(
     `SELECT id, name, how_to, equipment FROM exercises WHERE name IN (${defaultExerciseNames
       .map(() => '?')
       .join(', ')})`,
@@ -66,9 +66,9 @@ export function seedDefaultExercises(db: SQLiteDatabase): void {
     return;
   }
 
-  db.withTransactionSync(() => {
+  await db.withTransactionAsync(async () => {
     for (const entry of missingExercises) {
-      db.runSync(
+      await db.runAsync(
         'INSERT INTO exercises (id, name, muscle_group, how_to, equipment) VALUES (?, ?, ?, ?, ?)',
         [
           generateId(),
@@ -87,7 +87,7 @@ export function seedDefaultExercises(db: SQLiteDatabase): void {
         continue;
       }
 
-      db.runSync(
+      await db.runAsync(
         'UPDATE exercises SET how_to = COALESCE(how_to, ?), equipment = COALESCE(equipment, ?) WHERE id = ?',
         [entry.howTo ?? null, entry.equipment ?? null, existingExercise.id],
       );

--- a/src/core/notifications/__tests__/workout-timer-notification-coordinator.test.tsx
+++ b/src/core/notifications/__tests__/workout-timer-notification-coordinator.test.tsx
@@ -30,8 +30,8 @@ jest.mock('@core/navigation', () => ({
   navigateToActiveWorkoutScreen: mockNavigateToActiveWorkoutScreen,
 }));
 
-jest.mock('@core/database', () => ({
-  database: mockDatabase,
+jest.mock('@core/database/provider', () => ({
+  useDatabase: () => mockDatabase,
 }));
 
 jest.mock('@features/workout-mode', () => {

--- a/src/core/notifications/workout-timer-notification-coordinator.tsx
+++ b/src/core/notifications/workout-timer-notification-coordinator.tsx
@@ -17,7 +17,7 @@ import type { JSX } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-import { database } from '@core/database';
+import { useDatabase } from '@core/database/provider';
 import { navigateToActiveWorkoutScreen } from '@core/navigation';
 import {
   loadInProgressWorkoutSession,
@@ -101,6 +101,7 @@ function buildTimerRequests(
 }
 
 export function WorkoutTimerNotificationCoordinator(): JSX.Element | null {
+  const db = useDatabase();
   const {
     isWorkoutActive,
     activeSessionId,
@@ -155,7 +156,9 @@ export function WorkoutTimerNotificationCoordinator(): JSX.Element | null {
   }, []);
 
   useEffect(() => {
-    function restoreInProgressWorkout(sessionId?: string): boolean {
+    async function restoreInProgressWorkout(
+      sessionId?: string,
+    ): Promise<boolean> {
       const state = useWorkoutStore.getState();
       const isMatchingActiveSession =
         state.isWorkoutActive &&
@@ -165,8 +168,8 @@ export function WorkoutTimerNotificationCoordinator(): JSX.Element | null {
       }
 
       const restoredSession = sessionId
-        ? loadInProgressWorkoutSession(database, sessionId)
-        : loadLatestInProgressWorkoutSession(database);
+        ? await loadInProgressWorkoutSession(db, sessionId)
+        : await loadLatestInProgressWorkoutSession(db);
       if (!restoredSession) {
         return false;
       }
@@ -175,10 +178,12 @@ export function WorkoutTimerNotificationCoordinator(): JSX.Element | null {
       return true;
     }
 
-    function openActiveWorkoutFromNotification(sessionId: string): void {
+    async function openActiveWorkoutFromNotification(
+      sessionId: string,
+    ): Promise<void> {
       const state = useWorkoutStore.getState();
       if (!state.isWorkoutActive || state.activeSessionId !== sessionId) {
-        const wasRestored = restoreInProgressWorkout(sessionId);
+        const wasRestored = await restoreInProgressWorkout(sessionId);
         if (!wasRestored) {
           return;
         }
@@ -192,16 +197,18 @@ export function WorkoutTimerNotificationCoordinator(): JSX.Element | null {
     }
 
     const lastResponseData = getLastWorkoutTimerNotificationResponseData();
-    if (lastResponseData) {
-      openActiveWorkoutFromNotification(lastResponseData.sessionId);
-    } else {
-      restoreInProgressWorkout();
-    }
+    void (async () => {
+      if (lastResponseData) {
+        await openActiveWorkoutFromNotification(lastResponseData.sessionId);
+      } else {
+        await restoreInProgressWorkout();
+      }
+    })();
 
     return addWorkoutTimerNotificationResponseListener((data) => {
-      openActiveWorkoutFromNotification(data.sessionId);
+      void openActiveWorkoutFromNotification(data.sessionId);
     });
-  }, []);
+  }, [db]);
 
   useEffect(() => {
     let disposed = false;

--- a/src/core/performance/__tests__/workout-write-path.perf.test.tsx
+++ b/src/core/performance/__tests__/workout-write-path.perf.test.tsx
@@ -86,7 +86,7 @@ describe('workout write-path perf contracts', () => {
     jest.useRealTimers();
   });
 
-  it('updates RIR optimistically and defers sqlite writes until flush window', () => {
+  it('updates RIR optimistically and defers sqlite writes until flush window', async () => {
     const db = createMockDb();
     const dbTracker = createDbSyncCallTracker(db);
     const wrapper = createDatabaseWrapper(db);
@@ -110,8 +110,9 @@ describe('workout write-path perf contracts', () => {
     ).toBe(0);
 
     dbTracker.setPhase('effect');
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(200);
+      await Promise.resolve();
     });
 
     expect(
@@ -124,7 +125,7 @@ describe('workout write-path perf contracts', () => {
     dbTracker.restore();
   });
 
-  it('batches rapid reps and weight edits into deferred flush writes', () => {
+  it('batches rapid reps and weight edits into deferred flush writes', async () => {
     const db = createMockDb();
     const dbTracker = createDbSyncCallTracker(db);
     const wrapper = createDatabaseWrapper(db);
@@ -151,8 +152,9 @@ describe('workout write-path perf contracts', () => {
     ).toBe(0);
 
     dbTracker.setPhase('effect');
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(220);
+      await Promise.resolve();
     });
 
     expect(

--- a/src/core/performance/screens/perf-lab-screen.tsx
+++ b/src/core/performance/screens/perf-lab-screen.tsx
@@ -439,7 +439,8 @@ export function PerfLabScreen(): React.JSX.Element {
     const currentState = useWorkoutStore.getState();
 
     if (!currentState.isWorkoutActive) {
-      const startedSessionId = startWorkoutFromSchedule() ?? startFreeWorkout();
+      const startedSessionId =
+        (await startWorkoutFromSchedule()) ?? (await startFreeWorkout());
       if (!startedSessionId) {
         return;
       }
@@ -480,12 +481,12 @@ export function PerfLabScreen(): React.JSX.Element {
       }
 
       if (scenarioId === 'start-now') {
-        deleteWorkout();
+        await deleteWorkout();
         await navigateToTab('Workout');
         refreshPreview();
         await waitForFrames(2);
         const startedSessionId =
-          startWorkoutFromSchedule() ?? startFreeWorkout();
+          (await startWorkoutFromSchedule()) ?? (await startFreeWorkout());
         if (startedSessionId) {
           await waitForNavigationReady();
           rootNavigationRef.navigate('ActiveWorkout');
@@ -506,7 +507,7 @@ export function PerfLabScreen(): React.JSX.Element {
         updateWeight(targetSetId, 95 + sampleIndex * 2.5);
         updateActualRir(targetSetId, sampleIndex % 4);
         toggleSetLogged(targetSetId, sampleIndex % 2 === 0);
-        flushPendingWrites();
+        await flushPendingWrites();
         await waitForFrames(2);
         return;
       }

--- a/src/features/routines/index.ts
+++ b/src/features/routines/index.ts
@@ -20,6 +20,7 @@ export { useRoutineInsight } from './hooks/use-routine-insight';
 export { useRoutineTemplate } from './hooks/use-routine-template';
 export {
   insertRoutineExerciseTemplates,
+  loadRoutineExerciseTemplatesAsync,
   loadRoutineExerciseTemplates,
   replaceRoutineExerciseTemplates,
 } from './routine-template-repository';

--- a/src/features/routines/routine-template-repository.ts
+++ b/src/features/routines/routine-template-repository.ts
@@ -134,6 +134,84 @@ export function loadRoutineExerciseTemplates(
   });
 }
 
+export async function loadRoutineExerciseTemplatesAsync(
+  db: Pick<SQLiteDatabase, 'getAllAsync'>,
+  routineId: string,
+): Promise<RoutineExerciseTemplate[]> {
+  const exerciseRows = await db.getAllAsync<RoutineExercise>(
+    `SELECT id, routine_id, exercise_id, position, target_sets, target_reps, rest_seconds, progression_policy, target_rir
+     FROM routine_exercises
+     WHERE routine_id = ?
+     ORDER BY position ASC`,
+    [routineId],
+  );
+
+  if (exerciseRows.length === 0) {
+    return [];
+  }
+
+  const setRows = await db.getAllAsync<RoutineExerciseSet>(
+    `SELECT id, routine_exercise_id, position, target_reps, planned_weight, target_reps_min, target_reps_max, set_role
+     FROM routine_exercise_sets
+     WHERE routine_exercise_id IN (${exerciseRows.map(() => '?').join(', ')})
+     ORDER BY position ASC`,
+    exerciseRows.map((row) => row.id),
+  );
+
+  const setsByExerciseId = new Map<string, RoutineExerciseTemplateSet[]>();
+
+  for (const setRow of setRows) {
+    const sets = setsByExerciseId.get(setRow.routine_exercise_id) ?? [];
+    sets.push({
+      id: setRow.id,
+      position: setRow.position,
+      targetReps: setRow.target_reps,
+      targetRepsMin: setRow.target_reps_min ?? setRow.target_reps,
+      targetRepsMax:
+        setRow.target_reps_max ?? setRow.target_reps_min ?? setRow.target_reps,
+      plannedWeight: setRow.planned_weight,
+      setRole: setRow.set_role ?? 'work',
+    });
+    setsByExerciseId.set(setRow.routine_exercise_id, sets);
+  }
+
+  return exerciseRows.map((exerciseRow) => {
+    const sets =
+      setsByExerciseId.get(exerciseRow.id) ??
+      Array.from(
+        { length: Math.max(0, exerciseRow.target_sets) },
+        (_, index) => ({
+          id: `${exerciseRow.id}-legacy-${index}`,
+          position: index,
+          targetReps: exerciseRow.target_reps,
+          targetRepsMin: exerciseRow.target_reps,
+          targetRepsMax: exerciseRow.target_reps,
+          plannedWeight: null,
+          setRole:
+            exerciseRow.progression_policy === 'top_set_backoff'
+              ? index === 0
+                ? 'top_set'
+                : 'backoff'
+              : 'work',
+        }),
+      );
+
+    return {
+      id: exerciseRow.id,
+      exerciseId: exerciseRow.exercise_id,
+      position: exerciseRow.position,
+      restSeconds: exerciseRow.rest_seconds ?? null,
+      progressionPolicy: exerciseRow.progression_policy ?? 'double_progression',
+      targetRir: exerciseRow.target_rir ?? null,
+      targetSets: sets.length,
+      targetReps: sets[0]?.targetRepsMin ?? null,
+      targetRepsMin: sets[0]?.targetRepsMin ?? null,
+      targetRepsMax: sets[0]?.targetRepsMax ?? null,
+      sets,
+    };
+  });
+}
+
 export function insertRoutineExerciseTemplates(
   db: Pick<SQLiteDatabase, 'runSync'>,
   routineId: string,

--- a/src/features/routines/template-api.ts
+++ b/src/features/routines/template-api.ts
@@ -9,6 +9,7 @@
 
 export {
   insertRoutineExerciseTemplates,
+  loadRoutineExerciseTemplatesAsync,
   loadRoutineExerciseTemplates,
   replaceRoutineExerciseTemplates,
 } from './routine-template-repository';

--- a/src/features/workout-mode/__tests__/focused-workout-scene.guidance.test.tsx
+++ b/src/features/workout-mode/__tests__/focused-workout-scene.guidance.test.tsx
@@ -1,0 +1,201 @@
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import { FocusedWorkoutScene } from '../components/focused-workout-scene';
+import { useWorkoutStore } from '../store';
+import type { ActiveWorkoutSession } from '../types';
+
+const queuedStaleCommits: Array<() => void> = [];
+
+jest.mock('@shared/hooks', () => ({
+  useReducedMotionPreference: () => false,
+}));
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactNative = require('react-native');
+
+  return {
+    Feather: ({ name }: { name: string }) => (
+      <ReactNative.Text>{name}</ReactNative.Text>
+    ),
+  };
+});
+
+jest.mock('@quidone/react-native-wheel-picker', () => {
+  const React = require('react');
+  const ReactNative = require('react-native');
+
+  const MockWheelPicker = ({
+    value,
+    onValueChanging,
+    onValueChanged,
+    testID,
+  }: {
+    value: number;
+    onValueChanging?: (event: { item: { value: number } }) => void;
+    onValueChanged?: (event: { item: { value: number } }) => void;
+    testID?: string;
+  }): React.JSX.Element => {
+    React.useEffect(() => {
+      // Simulate library-driven programmatic sync updates when value prop changes.
+      onValueChanging?.({ item: { value: Math.max(0, value - 1) } });
+    }, [onValueChanging, value]);
+
+    React.useEffect(() => {
+      queuedStaleCommits.push(() => {
+        onValueChanged?.({ item: { value: value + 5 } });
+      });
+    }, [onValueChanged, value]);
+
+    return (
+      <ReactNative.Pressable
+        testID={`${testID}-commit`}
+        onPress={() => onValueChanged?.({ item: { value } })}
+      />
+    );
+  };
+
+  return {
+    __esModule: true,
+    default: MockWheelPicker,
+  };
+});
+
+const activeSession: ActiveWorkoutSession = {
+  id: 'session-1',
+  title: 'Push A',
+  startTime: new Date(2026, 2, 18, 8, 0, 0).getTime(),
+  isFreeWorkout: false,
+  exercises: [
+    {
+      exerciseId: 'exercise-1',
+      exerciseName: 'Bench Press',
+      targetSets: 2,
+      targetReps: 8,
+      targetRepsMin: 8,
+      targetRepsMax: 10,
+      sets: [
+        {
+          id: 'set-1',
+          exerciseId: 'exercise-1',
+          reps: 8,
+          weight: 135,
+          isCompleted: false,
+          targetSets: 2,
+          targetReps: 8,
+          targetRepsMin: 8,
+          targetRepsMax: 10,
+          actualRir: 2,
+        },
+        {
+          id: 'set-2',
+          exerciseId: 'exercise-1',
+          reps: 10,
+          weight: 155,
+          isCompleted: false,
+          targetSets: 2,
+          targetReps: 8,
+          targetRepsMin: 8,
+          targetRepsMax: 10,
+          actualRir: 0,
+        },
+      ],
+    },
+  ],
+};
+
+function seedActiveWorkout(): void {
+  useWorkoutStore.getState().endWorkout();
+  useWorkoutStore.getState().startWorkout(activeSession);
+}
+
+function FocusedWorkoutHarness(): React.JSX.Element {
+  const [focusedSetId, setFocusedSetId] = React.useState('set-1');
+
+  return (
+    <FocusedWorkoutScene
+      focusedSetId={focusedSetId}
+      headerHeight={96}
+      bottomInset={34}
+      previousPerformance={{
+        reps: 8,
+        weight: 130,
+        completedAt: new Date(2026, 2, 16, 9, 0, 0).getTime(),
+      }}
+      onOpenOverview={jest.fn()}
+      onOpenExerciseDetails={jest.fn()}
+      onOpenExerciseTimerOptions={jest.fn()}
+      onMoveFocus={(nextSetId) => {
+        if (nextSetId !== null) {
+          setFocusedSetId(nextSetId);
+        }
+      }}
+      onCompleteWorkout={jest.fn()}
+      updateReps={(setId, reps) => {
+        useWorkoutStore.getState().updateSet(setId, { reps });
+      }}
+      updateWeight={(setId, weight) => {
+        useWorkoutStore.getState().updateSet(setId, { weight });
+      }}
+      updateActualRir={(setId, actualRir) => {
+        useWorkoutStore.getState().updateSet(setId, { actualRir });
+      }}
+      toggleSetLogged={(setId, isCompleted) => {
+        useWorkoutStore.getState().updateSet(setId, { isCompleted });
+      }}
+    />
+  );
+}
+
+describe('focused workout scene guidance stability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queuedStaleCommits.length = 0;
+    seedActiveWorkout();
+  });
+
+  it('keeps set navigation to one focused-scene commit under programmatic wheel sync', () => {
+    const commits: Array<{ phase: string; actualDuration: number }> = [];
+
+    render(
+      <React.Profiler
+        id="FocusedWorkoutScene"
+        onRender={(_id, phase, actualDuration) => {
+          commits.push({ phase, actualDuration });
+        }}
+      >
+        <FocusedWorkoutHarness />
+      </React.Profiler>,
+    );
+
+    commits.length = 0;
+
+    act(() => {
+      fireEvent.press(screen.getByText('Next'));
+    });
+
+    expect(screen.getByText(/Set 2 of 2/)).toBeTruthy();
+    expect(screen.getByText('On target')).toBeTruthy();
+    expect(commits).toHaveLength(1);
+  });
+
+  it('ignores stale wheel commit callbacks after focus moves to another set', () => {
+    render(<FocusedWorkoutHarness />);
+
+    const staleCallbackCount = queuedStaleCommits.length;
+
+    act(() => {
+      fireEvent.press(screen.getByText('Next'));
+    });
+
+    act(() => {
+      queuedStaleCommits.slice(0, staleCallbackCount).forEach((callback) => {
+        callback();
+      });
+    });
+
+    const setOne = useWorkoutStore.getState().activeSetsById['set-1'];
+    expect(setOne?.reps).toBe(8);
+    expect(setOne?.weight).toBe(135);
+  });
+});

--- a/src/features/workout-mode/__tests__/hero-value-zone.test.tsx
+++ b/src/features/workout-mode/__tests__/hero-value-zone.test.tsx
@@ -3,66 +3,66 @@ import React from 'react';
 
 import { HeroValueZone } from '../components/hero-value-zone';
 
+void React;
+
 jest.mock('@quidone/react-native-wheel-picker', () => {
+  const React = require('react');
   const ReactNative = require('react-native');
+
+  const MockWheelPicker = ({
+    value,
+    onValueChanging,
+    onValueChanged,
+    testID,
+  }: {
+    value: number;
+    onValueChanging?: (event: { item: { value: number } }) => void;
+    onValueChanged?: (event: { item: { value: number } }) => void;
+    testID?: string;
+  }) => {
+    React.useEffect(() => {
+      onValueChanging?.({ item: { value: value + 1 } });
+    }, [onValueChanging, value]);
+
+    return (
+      <ReactNative.Pressable
+        testID={`${testID}-commit`}
+        onPress={() => onValueChanged?.({ item: { value } })}
+      />
+    );
+  };
 
   return {
     __esModule: true,
-    default: ({
-      onValueChanging,
-      onValueChanged,
-      _onScrollStart,
-      _onScrollEnd,
-    }: {
-      onValueChanging?: (event: { item: { value: number } }) => void;
-      onValueChanged?: (event: { item: { value: number } }) => void;
-      _onScrollStart?: () => void;
-      _onScrollEnd?: () => void;
-    }) => (
-      <ReactNative.View>
-        <ReactNative.Pressable
-          testID="wheel-programmatic-change"
-          onPress={() => onValueChanging?.({ item: { value: 95 } })}
-        />
-        <ReactNative.Pressable
-          testID="wheel-user-change"
-          onPress={() => {
-            _onScrollStart?.();
-            onValueChanging?.({ item: { value: 100 } });
-            _onScrollEnd?.();
-          }}
-        />
-        <ReactNative.Pressable
-          testID="wheel-value-changed"
-          onPress={() => onValueChanged?.({ item: { value: 100 } })}
-        />
-      </ReactNative.View>
-    ),
+    default: MockWheelPicker,
   };
 });
 
 describe('HeroValueZone', () => {
-  it('ignores non-user preview events while still committing value changes', () => {
-    const onPreviewValue = jest.fn();
+  it('ignores programmatic sync change events and commits only settled values', () => {
     const onCommitValue = jest.fn();
 
-    render(
+    const { rerender } = render(
       <HeroValueZone
         field="weight"
         value={90}
         options={[85, 90, 95, 100]}
-        onPreviewValue={onPreviewValue}
         onCommitValue={onCommitValue}
       />,
     );
 
-    fireEvent.press(screen.getByTestId('wheel-programmatic-change'));
-    expect(onPreviewValue).not.toHaveBeenCalled();
+    rerender(
+      <HeroValueZone
+        field="weight"
+        value={95}
+        options={[90, 95, 100, 105]}
+        onCommitValue={onCommitValue}
+      />,
+    );
 
-    fireEvent.press(screen.getByTestId('wheel-user-change'));
-    expect(onPreviewValue).toHaveBeenCalledWith(100);
+    expect(onCommitValue).not.toHaveBeenCalled();
 
-    fireEvent.press(screen.getByTestId('wheel-value-changed'));
-    expect(onCommitValue).toHaveBeenCalledWith(100);
+    fireEvent.press(screen.getByTestId('hero-zone-weight-wheel-commit'));
+    expect(onCommitValue).toHaveBeenCalledWith(95);
   });
 });

--- a/src/features/workout-mode/__tests__/hero-value-zone.test.tsx
+++ b/src/features/workout-mode/__tests__/hero-value-zone.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import { HeroValueZone } from '../components/hero-value-zone';
+
+jest.mock('@quidone/react-native-wheel-picker', () => {
+  const ReactNative = require('react-native');
+
+  return {
+    __esModule: true,
+    default: ({
+      onValueChanging,
+      onValueChanged,
+      _onScrollStart,
+      _onScrollEnd,
+    }: {
+      onValueChanging?: (event: { item: { value: number } }) => void;
+      onValueChanged?: (event: { item: { value: number } }) => void;
+      _onScrollStart?: () => void;
+      _onScrollEnd?: () => void;
+    }) => (
+      <ReactNative.View>
+        <ReactNative.Pressable
+          testID="wheel-programmatic-change"
+          onPress={() => onValueChanging?.({ item: { value: 95 } })}
+        />
+        <ReactNative.Pressable
+          testID="wheel-user-change"
+          onPress={() => {
+            _onScrollStart?.();
+            onValueChanging?.({ item: { value: 100 } });
+            _onScrollEnd?.();
+          }}
+        />
+        <ReactNative.Pressable
+          testID="wheel-value-changed"
+          onPress={() => onValueChanged?.({ item: { value: 100 } })}
+        />
+      </ReactNative.View>
+    ),
+  };
+});
+
+describe('HeroValueZone', () => {
+  it('ignores non-user preview events while still committing value changes', () => {
+    const onPreviewValue = jest.fn();
+    const onCommitValue = jest.fn();
+
+    render(
+      <HeroValueZone
+        field="weight"
+        value={90}
+        options={[85, 90, 95, 100]}
+        onPreviewValue={onPreviewValue}
+        onCommitValue={onCommitValue}
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('wheel-programmatic-change'));
+    expect(onPreviewValue).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByTestId('wheel-user-change'));
+    expect(onPreviewValue).toHaveBeenCalledWith(100);
+
+    fireEvent.press(screen.getByTestId('wheel-value-changed'));
+    expect(onCommitValue).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/features/workout-mode/__tests__/session-repository.test.tsx
+++ b/src/features/workout-mode/__tests__/session-repository.test.tsx
@@ -28,9 +28,9 @@ import {
 } from '../session-repository';
 
 describe('session-repository', () => {
-  it('merges legacy set-derived exercises with explicit session exercise rows', () => {
+  it('merges legacy set-derived exercises with explicit session exercise rows', async () => {
     const db = {
-      getFirstSync: jest.fn().mockImplementation((query: string) => {
+      getFirstAsync: jest.fn().mockImplementation(async (query: string) => {
         if (query.includes('FROM workout_sessions WHERE id = ?')) {
           return {
             id: 'session-1',
@@ -41,7 +41,7 @@ describe('session-repository', () => {
 
         return null;
       }),
-      getAllSync: jest.fn().mockImplementation((query: string) => {
+      getAllAsync: jest.fn().mockImplementation(async (query: string) => {
         if (query.includes('FROM workout_session_exercises')) {
           return [
             {
@@ -104,7 +104,9 @@ describe('session-repository', () => {
       }),
     };
 
-    expect(loadActiveWorkoutSession(db as never, 'session-1')).toEqual({
+    await expect(
+      loadActiveWorkoutSession(db as never, 'session-1'),
+    ).resolves.toEqual({
       id: 'session-1',
       title: 'Push A',
       startTime: 1,
@@ -198,9 +200,9 @@ describe('session-repository', () => {
     });
   });
 
-  it('loads only the latest completed performance row per exercise', () => {
+  it('loads only the latest completed performance row per exercise', async () => {
     const db = {
-      getAllSync: jest.fn().mockReturnValue([
+      getAllAsync: jest.fn().mockResolvedValue([
         {
           exercise_id: 'exercise-1',
           reps: 6,
@@ -216,12 +218,12 @@ describe('session-repository', () => {
       ]),
     };
 
-    expect(
+    await expect(
       loadPreviousExercisePerformanceMap(db as never, 'current-session', [
         'exercise-1',
         'exercise-2',
       ]),
-    ).toEqual({
+    ).resolves.toEqual({
       'exercise-1': {
         reps: 6,
         weight: 110,
@@ -234,7 +236,7 @@ describe('session-repository', () => {
       },
     });
 
-    expect(db.getAllSync).toHaveBeenCalledWith(
+    expect(db.getAllAsync).toHaveBeenCalledWith(
       expect.stringContaining('WITH latest_completed_sessions AS'),
       [
         'exercise-1',

--- a/src/features/workout-mode/__tests__/use-active-workout.test.tsx
+++ b/src/features/workout-mode/__tests__/use-active-workout.test.tsx
@@ -69,7 +69,7 @@ describe('useActiveWorkoutActions', () => {
     useWorkoutStore.getState().startWorkout(activeSession);
   });
 
-  it('adds and removes ad hoc exercises without subscribing to the full session tree', () => {
+  it('adds and removes ad hoc exercises without subscribing to the full session tree', async () => {
     const db = createMockDb();
     const wrapper = createDatabaseWrapper(db);
     useWorkoutStore.getState().endWorkout();
@@ -81,8 +81,9 @@ describe('useActiveWorkoutActions', () => {
 
     const { result } = renderHook(() => useActiveWorkoutActions(), { wrapper });
 
-    act(() => {
+    await act(async () => {
       result.current.addExercise('exercise-2', 'Goblet Squat');
+      await Promise.resolve();
     });
 
     expect(db.runSync).toHaveBeenCalledWith(
@@ -130,8 +131,9 @@ describe('useActiveWorkoutActions', () => {
       },
     ]);
 
-    act(() => {
+    await act(async () => {
       result.current.removeExercise('exercise-2');
+      await Promise.resolve();
     });
 
     expect(db.runSync).toHaveBeenCalledWith(
@@ -143,7 +145,7 @@ describe('useActiveWorkoutActions', () => {
     ).toEqual([]);
   });
 
-  it('persists set edits, additions, and deletions while keeping store selectors in sync', () => {
+  it('persists set edits, additions, and deletions while keeping store selectors in sync', async () => {
     jest.useFakeTimers();
 
     const db = createMockDb();
@@ -174,8 +176,8 @@ describe('useActiveWorkoutActions', () => {
       ),
     ).toBe(false);
 
-    act(() => {
-      result.current.flushPendingWrites();
+    await act(async () => {
+      await result.current.flushPendingWrites();
     });
 
     expect(db.runSync).toHaveBeenCalledWith(
@@ -183,9 +185,10 @@ describe('useActiveWorkoutActions', () => {
       [10, 145.5, 'set-1'],
     );
 
-    act(() => {
+    await act(async () => {
       result.current.addSet('exercise-1');
       result.current.deleteSet('set-1');
+      await Promise.resolve();
     });
 
     expect(
@@ -213,7 +216,7 @@ describe('useActiveWorkoutActions', () => {
     jest.useRealTimers();
   });
 
-  it('batches rapid RIR updates before flushing', () => {
+  it('batches rapid RIR updates before flushing', async () => {
     jest.useFakeTimers();
 
     const db = createMockDb();
@@ -238,8 +241,9 @@ describe('useActiveWorkoutActions', () => {
       ),
     ).toBe(false);
 
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(180);
+      await Promise.resolve();
     });
 
     const rirUpdateCalls = db.runSync.mock.calls.filter(([sql]) =>
@@ -255,7 +259,7 @@ describe('useActiveWorkoutActions', () => {
     jest.useRealTimers();
   });
 
-  it('flushes queued set changes before completing and deleting workouts', () => {
+  it('flushes queued set changes before completing and deleting workouts', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(1_700_000_123_000);
 
@@ -296,8 +300,8 @@ describe('useActiveWorkoutActions', () => {
       result.current.updateReps('set-1', 10);
     });
 
-    act(() => {
-      expect(result.current.completeWorkout()).toBe('session-1');
+    await act(async () => {
+      expect(await result.current.completeWorkout()).toBe('session-1');
     });
 
     const completedSetFlushIndex = db.runSync.mock.calls.findIndex(
@@ -326,8 +330,8 @@ describe('useActiveWorkoutActions', () => {
       result.current.updateWeight('set-1', 140);
     });
 
-    act(() => {
-      expect(result.current.deleteWorkout()).toBe(true);
+    await act(async () => {
+      expect(await result.current.deleteWorkout()).toBe(true);
     });
 
     const deletedSetFlushIndex = db.runSync.mock.calls.findIndex(

--- a/src/features/workout-mode/__tests__/use-active-workout.test.tsx
+++ b/src/features/workout-mode/__tests__/use-active-workout.test.tsx
@@ -11,6 +11,8 @@ import type { ActiveWorkoutSession } from '../types';
 jest.mock('@core/database/utils', () => ({
   generateId: jest.fn().mockReturnValue('new-set-1'),
 }));
+const mockGenerateId = jest.requireMock('@core/database/utils')
+  .generateId as jest.Mock;
 
 jest.mock('@lodev09/react-native-true-sheet', () => {
   const React = require('react');
@@ -65,6 +67,8 @@ const activeSession: ActiveWorkoutSession = {
 describe('useActiveWorkoutActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGenerateId.mockReset();
+    mockGenerateId.mockReturnValue('new-set-1');
     useWorkoutStore.getState().endWorkout();
     useWorkoutStore.getState().startWorkout(activeSession);
   });
@@ -214,6 +218,92 @@ describe('useActiveWorkoutActions', () => {
 
     unmount();
     jest.useRealTimers();
+  });
+
+  it('serializes rapid add-set mutations so set positions remain monotonic', async () => {
+    const db = createMockDb();
+    const wrapper = createDatabaseWrapper(db);
+    let maxPosition = 0;
+
+    db.getFirstSync.mockImplementation((sql: unknown) => {
+      if (
+        typeof sql === 'string' &&
+        sql.includes('SELECT MAX(position) AS max_position') &&
+        sql.includes('FROM workout_sets')
+      ) {
+        return { max_position: maxPosition };
+      }
+
+      return null;
+    });
+
+    db.runSync.mockImplementation((sql: unknown, params?: unknown[]) => {
+      if (
+        typeof sql === 'string' &&
+        sql.includes('INSERT INTO workout_sets') &&
+        params
+      ) {
+        const insertedPosition = params[3];
+        if (typeof insertedPosition === 'number') {
+          maxPosition = Math.max(maxPosition, insertedPosition);
+        }
+      }
+    });
+
+    let resolveFirstInsert: (() => void) | undefined;
+    const firstInsertGate = new Promise<void>((resolve) => {
+      resolveFirstInsert = resolve;
+    });
+    let workoutSetInsertCount = 0;
+    db.runAsync.mockImplementation(async (...args: unknown[]) => {
+      const [sql] = args;
+      if (
+        typeof sql === 'string' &&
+        sql.includes('INSERT INTO workout_sets') &&
+        workoutSetInsertCount === 0
+      ) {
+        workoutSetInsertCount += 1;
+        await firstInsertGate;
+      }
+
+      return db.runSync(...args);
+    });
+
+    mockGenerateId
+      .mockReturnValueOnce('new-set-2')
+      .mockReturnValueOnce('new-set-3');
+
+    const { result } = renderHook(() => useActiveWorkoutActions(), { wrapper });
+
+    await act(async () => {
+      result.current.addSet('exercise-1');
+      result.current.addSet('exercise-1');
+      await Promise.resolve();
+    });
+
+    const preReleasePositionReads = db.getFirstSync.mock.calls.filter(
+      ([sql]) =>
+        (sql as string).includes('SELECT MAX(position) AS max_position') &&
+        (sql as string).includes('FROM workout_sets'),
+    );
+    expect(preReleasePositionReads).toHaveLength(1);
+
+    if (resolveFirstInsert === undefined) {
+      throw new Error('Expected first insert gate release function to exist.');
+    }
+    resolveFirstInsert();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const workoutSetInsertCalls = db.runSync.mock.calls.filter(([sql]) =>
+      (sql as string).includes('INSERT INTO workout_sets'),
+    );
+    expect(
+      workoutSetInsertCalls.map(([, params]) => (params as unknown[])[3]),
+    ).toEqual([1, 2]);
   });
 
   it('batches rapid RIR updates before flushing', async () => {

--- a/src/features/workout-mode/__tests__/use-workout-starter.test.tsx
+++ b/src/features/workout-mode/__tests__/use-workout-starter.test.tsx
@@ -37,12 +37,12 @@ describe('useWorkoutStarter', () => {
     useWorkoutStore.getState().endWorkout();
   });
 
-  it('creates a session snapshot, placeholder sets, and hydrates the active store state', () => {
+  it('creates a session snapshot, placeholder sets, and hydrates the active store state', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(1_700_000_000_000);
 
     const db = createMockDb();
-    db.getFirstSync.mockImplementation((query: string, params?: unknown[]) => {
+    db.getFirstAsync.mockImplementation((query: string, params?: unknown[]) => {
       if (
         query.includes('FROM schedules WHERE is_active = 1 AND is_deleted = 0')
       ) {
@@ -65,7 +65,7 @@ describe('useWorkoutStarter', () => {
 
       return null;
     });
-    db.getAllSync.mockImplementation((query: string) => {
+    db.getAllAsync.mockImplementation((query: string) => {
       if (query.includes('FROM schedule_entries')) {
         return [
           {
@@ -110,27 +110,28 @@ describe('useWorkoutStarter', () => {
 
     const wrapper = createDatabaseWrapper(db);
     const { result } = renderHook(() => useWorkoutStarter(), { wrapper });
-    db.runSync.mockClear();
-    db.withTransactionSync.mockClear();
+    db.runAsync.mockClear();
+    db.withTransactionAsync.mockClear();
 
     let sessionId: string | null = null;
-    act(() => {
-      sessionId = result.current.startWorkoutFromSchedule();
+    await act(async () => {
+      sessionId = await result.current.startWorkoutFromSchedule();
     });
 
     expect(typeof sessionId).toBe('string');
     expect(sessionId).not.toHaveLength(0);
-    expect(db.withTransactionSync).toHaveBeenCalledTimes(1);
-    expect(db.runSync).toHaveBeenCalledWith(
+    expect(db.withTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(db.runAsync).toHaveBeenCalledWith(
       'INSERT INTO workout_sessions (id, routine_id, schedule_id, snapshot_name, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)',
       [sessionId, 'routine-1', 'schedule-1', 'Push A', 1_700_000_000_000, null],
     );
 
-    const setInsertCalls = db.runSync.mock.calls.filter(([query]) =>
+    const setInsertCalls = db.runAsync.mock.calls.filter(([query]) =>
       (query as string).includes('INSERT INTO workout_sets'),
     );
-    const sessionExerciseInsertCalls = db.runSync.mock.calls.filter(([query]) =>
-      (query as string).includes('INSERT INTO workout_session_exercises'),
+    const sessionExerciseInsertCalls = db.runAsync.mock.calls.filter(
+      ([query]) =>
+        (query as string).includes('INSERT INTO workout_session_exercises'),
     );
     expect(sessionExerciseInsertCalls).toHaveLength(2);
     expect(setInsertCalls).toHaveLength(3);
@@ -176,17 +177,17 @@ describe('useWorkoutStarter', () => {
       10,
       'work',
     ]);
-    expect(db.runSync).not.toHaveBeenCalledWith(
+    expect(db.runAsync).not.toHaveBeenCalledWith(
       'UPDATE schedules SET current_position = ? WHERE id = ?',
       [0, 'schedule-1'],
     );
     expect(
-      db.getAllSync.mock.calls.some(([query]) =>
+      db.getAllAsync.mock.calls.some(([query]) =>
         (query as string).includes('FROM workout_session_exercises'),
       ),
     ).toBe(false);
     expect(
-      db.getAllSync.mock.calls.some(([query]) =>
+      db.getAllAsync.mock.calls.some(([query]) =>
         (query as string).includes('FROM workout_sets ws'),
       ),
     ).toBe(false);

--- a/src/features/workout-mode/__tests__/workout-screen.test.tsx
+++ b/src/features/workout-mode/__tests__/workout-screen.test.tsx
@@ -385,6 +385,57 @@ describe('workout screens', () => {
     expect(screen.getByText(/Set 1 of 2/)).toBeTruthy();
   });
 
+  it('keeps completion navigation on summary when completion clears workout state', async () => {
+    const props = createWorkoutActiveScreenProps();
+    const completeWorkout = jest.fn().mockImplementation(async () => {
+      useWorkoutStore.getState().endWorkout();
+      return 'completed-session-1';
+    });
+
+    mockUseActiveWorkoutActions.mockReturnValue({
+      addExercise: jest.fn(),
+      removeExercise: jest.fn(),
+      addSet: jest.fn(),
+      deleteSet: jest.fn(),
+      updateExerciseRestSeconds: jest.fn(),
+      updateReps: jest.fn(),
+      updateWeight: jest.fn(),
+      updateActualRir: jest.fn(),
+      toggleSetLogged: jest.fn(),
+      flushPendingWrites: jest.fn().mockResolvedValue(undefined),
+      isCriticalMutationPending: false,
+      completeWorkout,
+      deleteWorkout: jest.fn().mockResolvedValue(true),
+    });
+
+    seedActiveWorkout({
+      ...activeSession,
+      exercises: [
+        {
+          ...activeSession.exercises[0],
+          sets: [activeSession.exercises[0].sets[0]],
+        },
+      ],
+    });
+
+    render(<WorkoutActiveScreen {...props} />);
+
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText('Complete Set'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(completeWorkout).toHaveBeenCalledTimes(1);
+    expect(props.navigation.replace).toHaveBeenCalledWith('WorkoutSummary', {
+      sessionId: 'completed-session-1',
+    });
+    expect(props.navigation.goBack).not.toHaveBeenCalled();
+    expect(props.navigation.navigate).not.toHaveBeenCalledWith('Tabs', {
+      screen: 'Workout',
+    });
+  });
+
   it('opens the workout overview without triggering a selector loop', () => {
     const props = createWorkoutActiveScreenProps();
 

--- a/src/features/workout-mode/__tests__/workout-screen.test.tsx
+++ b/src/features/workout-mode/__tests__/workout-screen.test.tsx
@@ -219,9 +219,10 @@ describe('workout screens', () => {
       updateWeight: jest.fn(),
       updateActualRir: jest.fn(),
       toggleSetLogged: jest.fn(),
-      flushPendingWrites: jest.fn(),
-      completeWorkout: jest.fn().mockReturnValue('completed-session-1'),
-      deleteWorkout: jest.fn().mockReturnValue(true),
+      flushPendingWrites: jest.fn().mockResolvedValue(undefined),
+      isCriticalMutationPending: false,
+      completeWorkout: jest.fn().mockResolvedValue('completed-session-1'),
+      deleteWorkout: jest.fn().mockResolvedValue(true),
     });
     mockUsePreviousExercisePerformance.mockReturnValue({
       'exercise-1': {
@@ -290,8 +291,9 @@ describe('workout screens', () => {
     >);
     mockUseWorkoutStarter.mockReturnValue({
       nextRoutine: null,
-      startWorkoutFromSchedule: jest.fn(),
-      startFreeWorkout: jest.fn(),
+      isStarting: false,
+      startWorkoutFromSchedule: jest.fn().mockResolvedValue(null),
+      startFreeWorkout: jest.fn().mockResolvedValue(''),
       refreshPreview: jest.fn(),
     });
 
@@ -305,10 +307,10 @@ describe('workout screens', () => {
     expect(expandWorkout).toHaveBeenCalledTimes(1);
   });
 
-  it('does not rerender the home shell while starting a scheduled workout', () => {
+  it('does not rerender the home shell while starting a scheduled workout', async () => {
     const props = createWorkoutTabScreenProps();
     const commits: string[] = [];
-    const startWorkoutFromSchedule = jest.fn().mockReturnValue('session-1');
+    const startWorkoutFromSchedule = jest.fn().mockResolvedValue('session-1');
 
     mockUseWorkoutStarter.mockReturnValue({
       nextRoutine: {
@@ -318,8 +320,9 @@ describe('workout screens', () => {
         exerciseCount: 5,
         estimatedMinutes: 45,
       },
+      isStarting: false,
       startWorkoutFromSchedule,
-      startFreeWorkout: jest.fn(),
+      startFreeWorkout: jest.fn().mockResolvedValue(''),
       refreshPreview: jest.fn(),
     });
 
@@ -336,8 +339,9 @@ describe('workout screens', () => {
 
     commits.length = 0;
 
-    act(() => {
+    await act(async () => {
       fireEvent(screen.getByText('Start now'), 'onPress');
+      await Promise.resolve();
     });
 
     expect(startWorkoutFromSchedule).toHaveBeenCalledTimes(1);

--- a/src/features/workout-mode/__tests__/workout-summary-screen.test.tsx
+++ b/src/features/workout-mode/__tests__/workout-summary-screen.test.tsx
@@ -30,6 +30,7 @@ describe('WorkoutSummaryScreen', () => {
   it('renders the completed workout summary with badges and schedule context', () => {
     const goBack = jest.fn();
     const navigate = jest.fn();
+    const reset = jest.fn();
 
     mockUseWorkoutSummary.mockReturnValue({
       isLoading: false,
@@ -96,6 +97,7 @@ describe('WorkoutSummaryScreen', () => {
             canGoBack: jest.fn(() => true),
             goBack,
             navigate,
+            reset,
             setOptions: jest.fn(),
           } as never
         }
@@ -119,7 +121,11 @@ describe('WorkoutSummaryScreen', () => {
 
     fireEvent.press(screen.getByText('Return Home'));
 
-    expect(goBack).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'Tabs', params: { screen: 'Workout' } }],
+    });
+    expect(goBack).not.toHaveBeenCalled();
     expect(navigate).not.toHaveBeenCalled();
   });
 

--- a/src/features/workout-mode/components/active-workout-content.tsx
+++ b/src/features/workout-mode/components/active-workout-content.tsx
@@ -52,7 +52,7 @@ export interface ActiveWorkoutContentProps {
   updateWeight: (setId: string, weight: number) => void;
   updateActualRir: (setId: string, actualRir: number | null) => void;
   toggleSetLogged: (setId: string, isCompleted: boolean) => void;
-  flushPendingWrites: () => void;
+  flushPendingWrites: () => Promise<void>;
   insets: ReturnType<typeof useSafeAreaInsets>;
 }
 

--- a/src/features/workout-mode/components/focused-set-hero.tsx
+++ b/src/features/workout-mode/components/focused-set-hero.tsx
@@ -4,7 +4,7 @@
  * CALLING SPEC:
  * - render the active workout hero with split weight and reps edit zones
  * - renders always-on weight and reps wheels with a strong centered focus
- * - previews wheel changes immediately and commits settled values upstream
+ * - use wheel motion as visual-only and commit settled values upstream
  * - owns success highlight treatment only
  * - has no persistence side effects on its own
  */
@@ -22,9 +22,7 @@ export interface FocusedSetHeroProps {
   weightValue: number;
   repsValue: number;
   previousSetSummary: string;
-  onPreviewWeight: (value: number) => void;
   onCommitWeight: (value: number) => void;
-  onPreviewReps: (value: number) => void;
   onCommitReps: (value: number) => void;
 }
 
@@ -32,9 +30,7 @@ export const FocusedSetHero = React.memo(function FocusedSetHero({
   weightValue,
   repsValue,
   previousSetSummary,
-  onPreviewWeight,
   onCommitWeight,
-  onPreviewReps,
   onCommitReps,
 }: FocusedSetHeroProps): React.JSX.Element {
   const { tokens } = useTheme();
@@ -56,7 +52,6 @@ export const FocusedSetHero = React.memo(function FocusedSetHero({
           field="weight"
           value={weightValue}
           options={weightOptions}
-          onPreviewValue={onPreviewWeight}
           onCommitValue={onCommitWeight}
         />
         <View
@@ -69,7 +64,6 @@ export const FocusedSetHero = React.memo(function FocusedSetHero({
           field="reps"
           value={repsValue}
           options={repOptions}
-          onPreviewValue={onPreviewReps}
           onCommitValue={onCommitReps}
         />
       </View>

--- a/src/features/workout-mode/components/focused-workout-scene.tsx
+++ b/src/features/workout-mode/components/focused-workout-scene.tsx
@@ -3,12 +3,12 @@
  *
  * CALLING SPEC:
  * - render one focused set without pager infrastructure
- * - own only draft state and explicit previous/next/skip navigation for the current set
+ * - update guidance from settled set values and explicit previous/next/skip navigation
  * - subscribe only to the current focused set and its timer state
  * - side effects: invokes optimistic workout actions supplied by the parent
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Alert, ScrollView, View, unstable_batchedUpdates } from 'react-native';
 
 import {
@@ -49,11 +49,6 @@ interface FocusedWorkoutSceneProps {
   toggleSetLogged: (setId: string, isCompleted: boolean) => void;
 }
 
-interface FocusedSetDraft {
-  reps: number;
-  weight: number;
-}
-
 function buildRirOptions(): Array<number | null> {
   return [null, 0, 1, 2, 3, 4];
 }
@@ -86,13 +81,13 @@ export function FocusedWorkoutScene({
   const { restTimerEndsAt, exerciseTimerEndsAt, exerciseTimerDuration } =
     useExerciseTimerState(sceneState?.exerciseId ?? '');
   const currentSet = sceneState?.set ?? null;
-  const [draftBySetId, setDraftBySetId] = useState<
-    Record<string, FocusedSetDraft>
-  >({});
-  const currentDraft =
-    currentSet === null ? null : (draftBySetId[currentSet.id] ?? null);
-  const selectedReps = currentDraft?.reps ?? currentSet?.reps ?? 0;
-  const selectedWeight = currentDraft?.weight ?? currentSet?.weight ?? 0;
+  const selectedReps = currentSet?.reps ?? 0;
+  const selectedWeight = currentSet?.weight ?? 0;
+  const activeFocusedSetIdRef = useRef<string | null>(focusedSetId);
+
+  useEffect(() => {
+    activeFocusedSetIdRef.current = focusedSetId;
+  }, [focusedSetId]);
 
   const sceneViewModel = useMemo(() => {
     if (sceneState === null) {
@@ -122,67 +117,25 @@ export function FocusedWorkoutScene({
     return <View className="flex-1" />;
   }
 
-  const updateDraft = (changes: Partial<FocusedSetDraft>): void => {
-    setDraftBySetId((currentDraftState) => {
-      const existingDraft = currentDraftState[sceneState.set.id] ?? {
-        reps: sceneState.set.reps,
-        weight: sceneState.set.weight,
-      };
-      const nextDraft = {
-        ...existingDraft,
-        ...changes,
-      };
-
-      if (
-        nextDraft.reps === sceneState.set.reps &&
-        nextDraft.weight === sceneState.set.weight
-      ) {
-        if (!(sceneState.set.id in currentDraftState)) {
-          return currentDraftState;
-        }
-
-        const { [sceneState.set.id]: _removedDraft, ...remainingDrafts } =
-          currentDraftState;
-        return remainingDrafts;
-      }
-
-      return {
-        ...currentDraftState,
-        [sceneState.set.id]: nextDraft,
-      };
-    });
-  };
-
-  const clearDraft = (setId: string): void => {
-    setDraftBySetId((currentDraftState) => {
-      if (!(setId in currentDraftState)) {
-        return currentDraftState;
-      }
-
-      const { [setId]: _removedDraft, ...remainingDrafts } = currentDraftState;
-      return remainingDrafts;
-    });
-  };
-
-  const handlePreviewReps = (nextReps: number): void => {
-    updateDraft({ reps: clampNumber(nextReps) });
-  };
-
-  const handlePreviewWeight = (nextWeight: number): void => {
-    updateDraft({ weight: clampNumber(nextWeight) });
-  };
-
   const handleAdjustReps = (
+    setId: string,
     nextReps: number,
     options?: { feedback?: boolean },
   ): void => {
-    const normalizedReps = clampNumber(nextReps);
-    updateDraft({ reps: normalizedReps });
+    if (activeFocusedSetIdRef.current !== setId) {
+      return;
+    }
 
-    if (normalizedReps !== sceneState.set.reps) {
-      updateReps(sceneState.set.id, normalizedReps);
-    } else {
-      clearDraft(sceneState.set.id);
+    const latestSet = useWorkoutStore.getState().activeSetsById[setId];
+
+    if (!latestSet) {
+      return;
+    }
+
+    const normalizedReps = clampNumber(nextReps);
+
+    if (normalizedReps !== latestSet.reps) {
+      updateReps(setId, normalizedReps);
     }
 
     if (options?.feedback !== false) {
@@ -191,16 +144,24 @@ export function FocusedWorkoutScene({
   };
 
   const handleAdjustWeight = (
+    setId: string,
     nextWeight: number,
     options?: { feedback?: boolean },
   ): void => {
-    const normalizedWeight = clampNumber(nextWeight);
-    updateDraft({ weight: normalizedWeight });
+    if (activeFocusedSetIdRef.current !== setId) {
+      return;
+    }
 
-    if (normalizedWeight !== sceneState.set.weight) {
-      updateWeight(sceneState.set.id, normalizedWeight);
-    } else {
-      clearDraft(sceneState.set.id);
+    const latestSet = useWorkoutStore.getState().activeSetsById[setId];
+
+    if (!latestSet) {
+      return;
+    }
+
+    const normalizedWeight = clampNumber(nextWeight);
+
+    if (normalizedWeight !== latestSet.weight) {
+      updateWeight(setId, normalizedWeight);
     }
 
     if (options?.feedback !== false) {
@@ -208,25 +169,7 @@ export function FocusedWorkoutScene({
     }
   };
 
-  const commitFocusedSetValues = (): void => {
-    if (selectedReps !== sceneState.set.reps) {
-      updateReps(sceneState.set.id, selectedReps);
-    }
-
-    if (selectedWeight !== sceneState.set.weight) {
-      updateWeight(sceneState.set.id, selectedWeight);
-    }
-
-    if (currentDraft !== null) {
-      clearDraft(sceneState.set.id);
-    }
-  };
-
   const handleAdjustRir = (nextRir: number | null): void => {
-    if (currentDraft !== null) {
-      commitFocusedSetValues();
-    }
-
     if ((sceneState.set.actualRir ?? null) !== nextRir) {
       updateActualRir(sceneState.set.id, nextRir);
     }
@@ -239,7 +182,6 @@ export function FocusedWorkoutScene({
       return;
     }
 
-    commitFocusedSetValues();
     onMoveFocus(sceneState.previousSetId);
   };
 
@@ -251,7 +193,6 @@ export function FocusedWorkoutScene({
       return;
     }
 
-    commitFocusedSetValues();
     onMoveFocus(sceneState.nextSetId);
   };
 
@@ -268,8 +209,6 @@ export function FocusedWorkoutScene({
   };
 
   const handleCompleteSet = (): void => {
-    commitFocusedSetValues();
-
     const didLogSet = !sceneState.set.isCompleted;
 
     if (didLogSet) {
@@ -325,13 +264,15 @@ export function FocusedWorkoutScene({
             weightValue={selectedWeight}
             repsValue={selectedReps}
             previousSetSummary={formatPreviousPerformance(previousPerformance)}
-            onPreviewWeight={handlePreviewWeight}
             onCommitWeight={(nextWeight) =>
-              handleAdjustWeight(nextWeight, { feedback: false })
+              handleAdjustWeight(sceneState.set.id, nextWeight, {
+                feedback: false,
+              })
             }
-            onPreviewReps={handlePreviewReps}
             onCommitReps={(nextReps) =>
-              handleAdjustReps(nextReps, { feedback: false })
+              handleAdjustReps(sceneState.set.id, nextReps, {
+                feedback: false,
+              })
             }
           />
 

--- a/src/features/workout-mode/components/hero-value-zone.tsx
+++ b/src/features/workout-mode/components/hero-value-zone.tsx
@@ -4,12 +4,12 @@
  * CALLING SPEC:
  * - render one weight or reps zone inside the focused workout hero
  * - shows a stable vertical wheel with one strongly focused current value
- * - previews wheel values locally and commits settled values upstream
+ * - treat wheel motion as visual-only and commit settled values upstream
  * - has no persistence side effects on its own
  */
 
 import WheelPicker from '@quidone/react-native-wheel-picker';
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { Text, View } from 'react-native';
 
 import { useTheme } from '@core/theme/theme-context';
@@ -20,7 +20,6 @@ interface HeroValueZoneProps {
   field: HeroValueField;
   value: number;
   options: number[];
-  onPreviewValue: (value: number) => void;
   onCommitValue: (value: number) => void;
   children?: React.ReactNode;
 }
@@ -39,12 +38,10 @@ export function HeroValueZone({
   field,
   value,
   options,
-  onPreviewValue,
   onCommitValue,
   children,
 }: HeroValueZoneProps): React.JSX.Element {
   const { tokens } = useTheme();
-  const isUserScrollActiveRef = useRef(false);
 
   const wheelData = useMemo(
     () => buildWheelData(field, options),
@@ -61,19 +58,6 @@ export function HeroValueZone({
         visibleItemCount={3}
         width="100%"
         enableScrollByTapOnItem
-        _onScrollStart={() => {
-          isUserScrollActiveRef.current = true;
-        }}
-        _onScrollEnd={() => {
-          isUserScrollActiveRef.current = false;
-        }}
-        onValueChanging={({ item }) => {
-          if (!isUserScrollActiveRef.current) {
-            return;
-          }
-
-          onPreviewValue(item.value);
-        }}
         onValueChanged={({ item }) => {
           onCommitValue(item.value);
         }}

--- a/src/features/workout-mode/components/hero-value-zone.tsx
+++ b/src/features/workout-mode/components/hero-value-zone.tsx
@@ -9,7 +9,7 @@
  */
 
 import WheelPicker from '@quidone/react-native-wheel-picker';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Text, View } from 'react-native';
 
 import { useTheme } from '@core/theme/theme-context';
@@ -44,6 +44,7 @@ export function HeroValueZone({
   children,
 }: HeroValueZoneProps): React.JSX.Element {
   const { tokens } = useTheme();
+  const isUserScrollActiveRef = useRef(false);
 
   const wheelData = useMemo(
     () => buildWheelData(field, options),
@@ -60,7 +61,17 @@ export function HeroValueZone({
         visibleItemCount={3}
         width="100%"
         enableScrollByTapOnItem
+        _onScrollStart={() => {
+          isUserScrollActiveRef.current = true;
+        }}
+        _onScrollEnd={() => {
+          isUserScrollActiveRef.current = false;
+        }}
         onValueChanging={({ item }) => {
+          if (!isUserScrollActiveRef.current) {
+            return;
+          }
+
           onPreviewValue(item.value);
         }}
         onValueChanged={({ item }) => {

--- a/src/features/workout-mode/hooks/use-active-workout.ts
+++ b/src/features/workout-mode/hooks/use-active-workout.ts
@@ -123,9 +123,23 @@ export function useActiveWorkoutActions(): {
   const pendingSetChangesRef = useRef<Record<string, QueuedSetChanges>>({});
   const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flushInFlightRef = useRef<Promise<void> | null>(null);
+  const mutationQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [isCriticalMutationPending, setIsCriticalMutationPending] =
     useState(false);
   const isCriticalMutationPendingRef = useRef(false);
+
+  const enqueueMutation = useCallback(
+    (mutation: () => Promise<void>): Promise<void> => {
+      const nextMutation = mutationQueueRef.current.then(mutation);
+      mutationQueueRef.current = nextMutation.catch(() => {});
+      return nextMutation;
+    },
+    [],
+  );
+
+  const waitForQueuedMutations = useCallback(async (): Promise<void> => {
+    await mutationQueueRef.current;
+  }, []);
 
   const flushPendingWrites = useCallback(async (): Promise<void> => {
     if (flushTimeoutRef.current !== null) {
@@ -207,7 +221,11 @@ export function useActiveWorkoutActions(): {
 
   const addExercise = useCallback(
     (exerciseId: string, exerciseName: string): void => {
-      void (async () => {
+      if (isCriticalMutationPendingRef.current) {
+        return;
+      }
+
+      void enqueueMutation(async () => {
         await flushPendingWrites();
 
         const currentState = useWorkoutStore.getState();
@@ -269,16 +287,20 @@ export function useActiveWorkoutActions(): {
           targetRepsMax: null,
           sets: [newSet],
         });
-      })().catch((error: unknown) => {
+      }).catch((error: unknown) => {
         console.error('[Workout] Failed to add exercise:', error);
       });
     },
-    [addExerciseToStore, db, flushPendingWrites],
+    [addExerciseToStore, db, enqueueMutation, flushPendingWrites],
   );
 
   const removeExercise = useCallback(
     (exerciseId: string): void => {
-      void (async () => {
+      if (isCriticalMutationPendingRef.current) {
+        return;
+      }
+
+      void enqueueMutation(async () => {
         await flushPendingWrites();
 
         const currentState = useWorkoutStore.getState();
@@ -294,11 +316,11 @@ export function useActiveWorkoutActions(): {
           exerciseId,
         );
         removeExerciseFromStore(exerciseId);
-      })().catch((error: unknown) => {
+      }).catch((error: unknown) => {
         console.error('[Workout] Failed to remove exercise:', error);
       });
     },
-    [db, flushPendingWrites, removeExerciseFromStore],
+    [db, enqueueMutation, flushPendingWrites, removeExerciseFromStore],
   );
 
   const updateReps = useCallback(
@@ -341,7 +363,11 @@ export function useActiveWorkoutActions(): {
 
   const addSet = useCallback(
     (exerciseId: string): void => {
-      void (async () => {
+      if (isCriticalMutationPendingRef.current) {
+        return;
+      }
+
+      void enqueueMutation(async () => {
         await flushPendingWrites();
 
         const currentState = useWorkoutStore.getState();
@@ -380,29 +406,37 @@ export function useActiveWorkoutActions(): {
         );
 
         addSetToStore(exerciseId, newSet);
-      })().catch((error: unknown) => {
+      }).catch((error: unknown) => {
         console.error('[Workout] Failed to add set:', error);
       });
     },
-    [addSetToStore, db, flushPendingWrites],
+    [addSetToStore, db, enqueueMutation, flushPendingWrites],
   );
 
   const deleteSet = useCallback(
     (setId: string): void => {
-      void (async () => {
+      if (isCriticalMutationPendingRef.current) {
+        return;
+      }
+
+      void enqueueMutation(async () => {
         await flushPendingWrites();
         await deleteWorkoutSetRecord(db, setId);
         deleteSetFromStore(setId);
-      })().catch((error: unknown) => {
+      }).catch((error: unknown) => {
         console.error('[Workout] Failed to delete set:', error);
       });
     },
-    [db, deleteSetFromStore, flushPendingWrites],
+    [db, deleteSetFromStore, enqueueMutation, flushPendingWrites],
   );
 
   const updateExerciseRestSeconds = useCallback(
     (exerciseId: string, restSeconds: number): void => {
-      void (async () => {
+      if (isCriticalMutationPendingRef.current) {
+        return;
+      }
+
+      void enqueueMutation(async () => {
         const currentActiveSessionId =
           useWorkoutStore.getState().activeSessionId;
 
@@ -416,11 +450,11 @@ export function useActiveWorkoutActions(): {
           exerciseId,
           restSeconds,
         );
-      })().catch((error: unknown) => {
+      }).catch((error: unknown) => {
         console.error('[Workout] Failed to update exercise rest timer:', error);
       });
     },
-    [db],
+    [db, enqueueMutation],
   );
 
   const toggleSetLogged = useCallback(
@@ -467,6 +501,7 @@ export function useActiveWorkoutActions(): {
     setIsCriticalMutationPending(true);
 
     try {
+      await waitForQueuedMutations();
       await flushPendingWrites();
       await completeWorkoutSessionRecord(db, activeSessionId, Date.now());
       endWorkout();
@@ -475,7 +510,7 @@ export function useActiveWorkoutActions(): {
       isCriticalMutationPendingRef.current = false;
       setIsCriticalMutationPending(false);
     }
-  }, [db, endWorkout, flushPendingWrites]);
+  }, [db, endWorkout, flushPendingWrites, waitForQueuedMutations]);
 
   const deleteWorkout = useCallback(async (): Promise<boolean> => {
     if (isCriticalMutationPendingRef.current) {
@@ -492,6 +527,7 @@ export function useActiveWorkoutActions(): {
     setIsCriticalMutationPending(true);
 
     try {
+      await waitForQueuedMutations();
       await flushPendingWrites();
       await deleteWorkoutSessionRecord(db, activeSessionId);
       endWorkout();
@@ -500,7 +536,7 @@ export function useActiveWorkoutActions(): {
       isCriticalMutationPendingRef.current = false;
       setIsCriticalMutationPending(false);
     }
-  }, [db, endWorkout, flushPendingWrites]);
+  }, [db, endWorkout, flushPendingWrites, waitForQueuedMutations]);
 
   return useMemo(
     () => ({

--- a/src/features/workout-mode/hooks/use-active-workout.ts
+++ b/src/features/workout-mode/hooks/use-active-workout.ts
@@ -8,7 +8,7 @@
  * - side effects: sqlite reads and writes, app-state flush handling
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 
 import { useDatabase } from '@core/database/provider';
@@ -74,15 +74,25 @@ export function useEnsureActiveWorkoutLoaded(): void {
   const startWorkout = useWorkoutStore((state) => state.startWorkout);
 
   useEffect(() => {
-    if (!activeSessionId || activeSessionMeta !== null) {
-      return;
+    let isCancelled = false;
+
+    async function ensureLoaded(): Promise<void> {
+      if (!activeSessionId || activeSessionMeta !== null) {
+        return;
+      }
+
+      const session = await loadActiveWorkoutSession(db, activeSessionId);
+
+      if (!isCancelled && session) {
+        startWorkout(session);
+      }
     }
 
-    const session = loadActiveWorkoutSession(db, activeSessionId);
+    void ensureLoaded();
 
-    if (session) {
-      startWorkout(session);
-    }
+    return () => {
+      isCancelled = true;
+    };
   }, [activeSessionId, activeSessionMeta, db, startWorkout]);
 }
 
@@ -96,9 +106,10 @@ export function useActiveWorkoutActions(): {
   updateWeight: (setId: string, weight: number) => void;
   updateActualRir: (setId: string, actualRir: number | null) => void;
   toggleSetLogged: (setId: string, isCompleted: boolean) => void;
-  flushPendingWrites: () => void;
-  completeWorkout: () => string | null;
-  deleteWorkout: () => boolean;
+  flushPendingWrites: () => Promise<void>;
+  isCriticalMutationPending: boolean;
+  completeWorkout: () => Promise<string | null>;
+  deleteWorkout: () => Promise<boolean>;
 } {
   const db = useDatabase();
   const addExerciseToStore = useWorkoutStore((state) => state.addExercise);
@@ -111,8 +122,12 @@ export function useActiveWorkoutActions(): {
   const endWorkout = useWorkoutStore((state) => state.endWorkout);
   const pendingSetChangesRef = useRef<Record<string, QueuedSetChanges>>({});
   const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flushInFlightRef = useRef<Promise<void> | null>(null);
+  const [isCriticalMutationPending, setIsCriticalMutationPending] =
+    useState(false);
+  const isCriticalMutationPendingRef = useRef(false);
 
-  const flushPendingWrites = useCallback((): void => {
+  const flushPendingWrites = useCallback(async (): Promise<void> => {
     if (flushTimeoutRef.current !== null) {
       clearTimeout(flushTimeoutRef.current);
       flushTimeoutRef.current = null;
@@ -122,16 +137,28 @@ export function useActiveWorkoutActions(): {
     const pendingEntries = Object.entries(pendingSetChanges);
 
     if (pendingEntries.length === 0) {
+      if (flushInFlightRef.current) {
+        await flushInFlightRef.current;
+      }
       return;
     }
 
     pendingSetChangesRef.current = {};
 
-    db.withTransactionSync(() => {
-      pendingEntries.forEach(([setId, changes]) => {
-        updateWorkoutSetFields(db, setId, changes);
-      });
+    const flushPromise = db.withTransactionAsync(async () => {
+      for (const [setId, changes] of pendingEntries) {
+        await updateWorkoutSetFields(db, setId, changes);
+      }
     });
+    flushInFlightRef.current = flushPromise;
+
+    try {
+      await flushPromise;
+    } finally {
+      if (flushInFlightRef.current === flushPromise) {
+        flushInFlightRef.current = null;
+      }
+    }
   }, [db]);
 
   const schedulePendingFlush = useCallback((): void => {
@@ -141,7 +168,7 @@ export function useActiveWorkoutActions(): {
 
     flushTimeoutRef.current = setTimeout(() => {
       flushTimeoutRef.current = null;
-      flushPendingWrites();
+      void flushPendingWrites();
     }, PERSISTENCE_FLUSH_DELAY_MS);
   }, [flushPendingWrites]);
 
@@ -162,7 +189,7 @@ export function useActiveWorkoutActions(): {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       if (nextAppState !== 'active') {
-        flushPendingWrites();
+        void flushPendingWrites();
       }
     });
 
@@ -174,68 +201,76 @@ export function useActiveWorkoutActions(): {
         flushTimeoutRef.current = null;
       }
 
-      flushPendingWrites();
+      void flushPendingWrites();
     };
   }, [flushPendingWrites]);
 
   const addExercise = useCallback(
     (exerciseId: string, exerciseName: string): void => {
-      flushPendingWrites();
+      void (async () => {
+        await flushPendingWrites();
 
-      const currentState = useWorkoutStore.getState();
-      const currentActiveSessionId = currentState.activeSessionId;
+        const currentState = useWorkoutStore.getState();
+        const currentActiveSessionId = currentState.activeSessionId;
 
-      if (
-        !currentActiveSessionId ||
-        currentState.activeExercisesById[exerciseId]
-      ) {
-        return;
-      }
+        if (
+          !currentActiveSessionId ||
+          currentState.activeExercisesById[exerciseId]
+        ) {
+          return;
+        }
 
-      const nextExercisePosition = Math.max(
-        currentState.activeExerciseOrder.length,
-        getNextWorkoutSessionExercisePosition(db, currentActiveSessionId),
-      );
-      let newSet: ReturnType<typeof createWorkoutSetRecord> | null = null;
-
-      db.withTransactionSync(() => {
-        newSet = createWorkoutSetRecord(
-          db,
-          currentActiveSessionId,
-          exerciseId,
-          0,
-          0,
-          null,
-          null,
-          null,
-          'optional',
+        const nextExercisePosition = Math.max(
+          currentState.activeExerciseOrder.length,
+          await getNextWorkoutSessionExercisePosition(
+            db,
+            currentActiveSessionId,
+          ),
         );
-        createWorkoutSessionExerciseRecord(
-          db,
-          currentActiveSessionId,
+        let newSet: Awaited<ReturnType<typeof createWorkoutSetRecord>> | null =
+          null;
+
+        await db.withTransactionAsync(async () => {
+          newSet = await createWorkoutSetRecord(
+            db,
+            currentActiveSessionId,
+            exerciseId,
+            0,
+            0,
+            null,
+            null,
+            null,
+            'optional',
+          );
+          await createWorkoutSessionExerciseRecord(
+            db,
+            currentActiveSessionId,
+            exerciseId,
+            nextExercisePosition,
+            DEFAULT_EXERCISE_TIMER_SECONDS,
+            'double_progression',
+            null,
+          );
+        });
+
+        if (!newSet) {
+          return;
+        }
+
+        addExerciseToStore({
           exerciseId,
-          nextExercisePosition,
-          DEFAULT_EXERCISE_TIMER_SECONDS,
-          'double_progression',
-          null,
-        );
-      });
-
-      if (!newSet) {
-        return;
-      }
-
-      addExerciseToStore({
-        exerciseId,
-        exerciseName,
-        restSeconds: DEFAULT_EXERCISE_TIMER_SECONDS,
-        progressionPolicy: 'double_progression',
-        targetRir: null,
-        targetSets: null,
-        targetReps: null,
-        targetRepsMin: null,
-        targetRepsMax: null,
-        sets: [newSet],
+          exerciseName,
+          restSeconds: DEFAULT_EXERCISE_TIMER_SECONDS,
+          progressionPolicy: 'double_progression',
+          targetRir: null,
+          targetSets: null,
+          targetReps: null,
+          targetRepsMin: null,
+          targetRepsMax: null,
+          sets: [newSet],
+        });
+      })().catch((error: unknown) => {
+        console.error('[Workout] Failed to add exercise:', error);
       });
     },
     [addExerciseToStore, db, flushPendingWrites],
@@ -243,17 +278,25 @@ export function useActiveWorkoutActions(): {
 
   const removeExercise = useCallback(
     (exerciseId: string): void => {
-      flushPendingWrites();
+      void (async () => {
+        await flushPendingWrites();
 
-      const currentState = useWorkoutStore.getState();
-      const currentActiveSessionId = currentState.activeSessionId;
+        const currentState = useWorkoutStore.getState();
+        const currentActiveSessionId = currentState.activeSessionId;
 
-      if (!currentActiveSessionId) {
-        return;
-      }
+        if (!currentActiveSessionId) {
+          return;
+        }
 
-      deleteWorkoutExerciseRecords(db, currentActiveSessionId, exerciseId);
-      removeExerciseFromStore(exerciseId);
+        await deleteWorkoutExerciseRecords(
+          db,
+          currentActiveSessionId,
+          exerciseId,
+        );
+        removeExerciseFromStore(exerciseId);
+      })().catch((error: unknown) => {
+        console.error('[Workout] Failed to remove exercise:', error);
+      });
     },
     [db, flushPendingWrites, removeExerciseFromStore],
   );
@@ -298,71 +341,84 @@ export function useActiveWorkoutActions(): {
 
   const addSet = useCallback(
     (exerciseId: string): void => {
-      flushPendingWrites();
+      void (async () => {
+        await flushPendingWrites();
 
-      const currentState = useWorkoutStore.getState();
-      const currentActiveSessionId = currentState.activeSessionId;
-      const currentExercise = currentState.activeExercisesById[exerciseId];
+        const currentState = useWorkoutStore.getState();
+        const currentActiveSessionId = currentState.activeSessionId;
+        const currentExercise = currentState.activeExercisesById[exerciseId];
 
-      if (!currentActiveSessionId || !currentExercise) {
-        return;
-      }
+        if (!currentActiveSessionId || !currentExercise) {
+          return;
+        }
 
-      const previousSetId = currentExercise.setIds.at(-1);
-      const previousSet =
-        previousSetId === undefined
-          ? null
-          : (currentState.activeSetsById[previousSetId] ?? null);
-      const newSet = createWorkoutSetRecord(
-        db,
-        currentActiveSessionId,
-        exerciseId,
-        previousSet?.reps ?? 0,
-        previousSet?.weight ?? 0,
-        currentExercise.targetSets ?? previousSet?.targetSets ?? null,
-        currentExercise.targetRepsMin ??
-          currentExercise.targetReps ??
-          previousSet?.targetRepsMin ??
-          previousSet?.targetReps ??
-          null,
-        currentExercise.targetRepsMax ??
+        const previousSetId = currentExercise.setIds.at(-1);
+        const previousSet =
+          previousSetId === undefined
+            ? null
+            : (currentState.activeSetsById[previousSetId] ?? null);
+        const newSet = await createWorkoutSetRecord(
+          db,
+          currentActiveSessionId,
+          exerciseId,
+          previousSet?.reps ?? 0,
+          previousSet?.weight ?? 0,
+          currentExercise.targetSets ?? previousSet?.targetSets ?? null,
           currentExercise.targetRepsMin ??
-          currentExercise.targetReps ??
-          previousSet?.targetRepsMax ??
-          previousSet?.targetRepsMin ??
-          previousSet?.targetReps ??
-          null,
-        'optional',
-      );
+            currentExercise.targetReps ??
+            previousSet?.targetRepsMin ??
+            previousSet?.targetReps ??
+            null,
+          currentExercise.targetRepsMax ??
+            currentExercise.targetRepsMin ??
+            currentExercise.targetReps ??
+            previousSet?.targetRepsMax ??
+            previousSet?.targetRepsMin ??
+            previousSet?.targetReps ??
+            null,
+          'optional',
+        );
 
-      addSetToStore(exerciseId, newSet);
+        addSetToStore(exerciseId, newSet);
+      })().catch((error: unknown) => {
+        console.error('[Workout] Failed to add set:', error);
+      });
     },
     [addSetToStore, db, flushPendingWrites],
   );
 
   const deleteSet = useCallback(
     (setId: string): void => {
-      flushPendingWrites();
-      deleteWorkoutSetRecord(db, setId);
-      deleteSetFromStore(setId);
+      void (async () => {
+        await flushPendingWrites();
+        await deleteWorkoutSetRecord(db, setId);
+        deleteSetFromStore(setId);
+      })().catch((error: unknown) => {
+        console.error('[Workout] Failed to delete set:', error);
+      });
     },
     [db, deleteSetFromStore, flushPendingWrites],
   );
 
   const updateExerciseRestSeconds = useCallback(
     (exerciseId: string, restSeconds: number): void => {
-      const currentActiveSessionId = useWorkoutStore.getState().activeSessionId;
+      void (async () => {
+        const currentActiveSessionId =
+          useWorkoutStore.getState().activeSessionId;
 
-      if (!currentActiveSessionId) {
-        return;
-      }
+        if (!currentActiveSessionId) {
+          return;
+        }
 
-      updateWorkoutSessionExerciseRest(
-        db,
-        currentActiveSessionId,
-        exerciseId,
-        restSeconds,
-      );
+        await updateWorkoutSessionExerciseRest(
+          db,
+          currentActiveSessionId,
+          exerciseId,
+          restSeconds,
+        );
+      })().catch((error: unknown) => {
+        console.error('[Workout] Failed to update exercise rest timer:', error);
+      });
     },
     [db],
   );
@@ -396,8 +452,10 @@ export function useActiveWorkoutActions(): {
     [queueSetChanges, updateSet],
   );
 
-  const completeWorkout = useCallback((): string | null => {
-    flushPendingWrites();
+  const completeWorkout = useCallback(async (): Promise<string | null> => {
+    if (isCriticalMutationPendingRef.current) {
+      return null;
+    }
 
     const activeSessionId = useWorkoutStore.getState().activeSessionId;
 
@@ -405,13 +463,24 @@ export function useActiveWorkoutActions(): {
       return null;
     }
 
-    completeWorkoutSessionRecord(db, activeSessionId, Date.now());
-    endWorkout();
-    return activeSessionId;
+    isCriticalMutationPendingRef.current = true;
+    setIsCriticalMutationPending(true);
+
+    try {
+      await flushPendingWrites();
+      await completeWorkoutSessionRecord(db, activeSessionId, Date.now());
+      endWorkout();
+      return activeSessionId;
+    } finally {
+      isCriticalMutationPendingRef.current = false;
+      setIsCriticalMutationPending(false);
+    }
   }, [db, endWorkout, flushPendingWrites]);
 
-  const deleteWorkout = useCallback((): boolean => {
-    flushPendingWrites();
+  const deleteWorkout = useCallback(async (): Promise<boolean> => {
+    if (isCriticalMutationPendingRef.current) {
+      return false;
+    }
 
     const activeSessionId = useWorkoutStore.getState().activeSessionId;
 
@@ -419,9 +488,18 @@ export function useActiveWorkoutActions(): {
       return false;
     }
 
-    deleteWorkoutSessionRecord(db, activeSessionId);
-    endWorkout();
-    return true;
+    isCriticalMutationPendingRef.current = true;
+    setIsCriticalMutationPending(true);
+
+    try {
+      await flushPendingWrites();
+      await deleteWorkoutSessionRecord(db, activeSessionId);
+      endWorkout();
+      return true;
+    } finally {
+      isCriticalMutationPendingRef.current = false;
+      setIsCriticalMutationPending(false);
+    }
   }, [db, endWorkout, flushPendingWrites]);
 
   return useMemo(
@@ -436,6 +514,7 @@ export function useActiveWorkoutActions(): {
       updateActualRir,
       toggleSetLogged,
       flushPendingWrites,
+      isCriticalMutationPending,
       completeWorkout,
       deleteWorkout,
     }),
@@ -450,6 +529,7 @@ export function useActiveWorkoutActions(): {
       updateActualRir,
       toggleSetLogged,
       flushPendingWrites,
+      isCriticalMutationPending,
       completeWorkout,
       deleteWorkout,
     ],

--- a/src/features/workout-mode/hooks/use-previous-exercise-performance.ts
+++ b/src/features/workout-mode/hooks/use-previous-exercise-performance.ts
@@ -8,7 +8,7 @@
  * - side effects: sqlite reads
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useDatabase } from '@core/database/provider';
 import { loadPreviousExercisePerformanceMap } from '../session-repository';
@@ -25,20 +25,26 @@ export function usePreviousExercisePerformance(
   const cacheRef = useRef<Record<string, PreviousExercisePerformance | null>>(
     {},
   );
-  const exerciseKey = exerciseIds.join('|');
+  const requestIdRef = useRef(0);
+  const exerciseKey = exerciseIds.filter(Boolean).join('|');
+  const requestedExerciseIds = useMemo(
+    () => (exerciseKey.length === 0 ? [] : exerciseKey.split('|')),
+    [exerciseKey],
+  );
 
   useEffect(() => {
     let isCancelled = false;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
 
     async function hydratePreviousPerformance(): Promise<void> {
-      if (!currentSessionId || exerciseIds.length === 0) {
-        if (!isCancelled) {
+      if (!currentSessionId || requestedExerciseIds.length === 0) {
+        if (!isCancelled && requestId === requestIdRef.current) {
           setPerformanceByExerciseId({});
         }
         return;
       }
 
-      const requestedExerciseIds = exerciseIds.filter(Boolean);
       const missingExerciseIds = requestedExerciseIds.filter(
         (exerciseId) =>
           cacheRef.current[`${currentSessionId}:${exerciseId}`] === undefined,
@@ -50,6 +56,10 @@ export function usePreviousExercisePerformance(
           currentSessionId,
           missingExerciseIds,
         );
+
+        if (isCancelled || requestId !== requestIdRef.current) {
+          return;
+        }
 
         missingExerciseIds.forEach((exerciseId) => {
           cacheRef.current[`${currentSessionId}:${exerciseId}`] =
@@ -64,7 +74,7 @@ export function usePreviousExercisePerformance(
         ]),
       );
 
-      if (isCancelled) {
+      if (isCancelled || requestId !== requestIdRef.current) {
         return;
       }
 
@@ -91,7 +101,7 @@ export function usePreviousExercisePerformance(
     return () => {
       isCancelled = true;
     };
-  }, [currentSessionId, db, exerciseIds, exerciseKey]);
+  }, [currentSessionId, db, requestedExerciseIds]);
 
   return performanceByExerciseId;
 }

--- a/src/features/workout-mode/hooks/use-previous-exercise-performance.ts
+++ b/src/features/workout-mode/hooks/use-previous-exercise-performance.ts
@@ -28,53 +28,69 @@ export function usePreviousExercisePerformance(
   const exerciseKey = exerciseIds.join('|');
 
   useEffect(() => {
-    if (!currentSessionId || exerciseIds.length === 0) {
-      setPerformanceByExerciseId({});
-      return;
-    }
+    let isCancelled = false;
 
-    const requestedExerciseIds = exerciseIds.filter(Boolean);
-    const missingExerciseIds = requestedExerciseIds.filter(
-      (exerciseId) =>
-        cacheRef.current[`${currentSessionId}:${exerciseId}`] === undefined,
-    );
+    async function hydratePreviousPerformance(): Promise<void> {
+      if (!currentSessionId || exerciseIds.length === 0) {
+        if (!isCancelled) {
+          setPerformanceByExerciseId({});
+        }
+        return;
+      }
 
-    if (missingExerciseIds.length > 0) {
-      const loadedPerformance = loadPreviousExercisePerformanceMap(
-        db,
-        currentSessionId,
-        missingExerciseIds,
+      const requestedExerciseIds = exerciseIds.filter(Boolean);
+      const missingExerciseIds = requestedExerciseIds.filter(
+        (exerciseId) =>
+          cacheRef.current[`${currentSessionId}:${exerciseId}`] === undefined,
       );
 
-      missingExerciseIds.forEach((exerciseId) => {
-        cacheRef.current[`${currentSessionId}:${exerciseId}`] =
-          loadedPerformance[exerciseId] ?? null;
+      if (missingExerciseIds.length > 0) {
+        const loadedPerformance = await loadPreviousExercisePerformanceMap(
+          db,
+          currentSessionId,
+          missingExerciseIds,
+        );
+
+        missingExerciseIds.forEach((exerciseId) => {
+          cacheRef.current[`${currentSessionId}:${exerciseId}`] =
+            loadedPerformance[exerciseId] ?? null;
+        });
+      }
+
+      const nextPerformanceByExerciseId = Object.fromEntries(
+        requestedExerciseIds.map((exerciseId) => [
+          exerciseId,
+          cacheRef.current[`${currentSessionId}:${exerciseId}`] ?? null,
+        ]),
+      );
+
+      if (isCancelled) {
+        return;
+      }
+
+      setPerformanceByExerciseId((currentPerformanceByExerciseId) => {
+        const currentKeys = Object.keys(currentPerformanceByExerciseId);
+
+        if (
+          currentKeys.length === requestedExerciseIds.length &&
+          requestedExerciseIds.every(
+            (exerciseId) =>
+              currentPerformanceByExerciseId[exerciseId] ===
+              nextPerformanceByExerciseId[exerciseId],
+          )
+        ) {
+          return currentPerformanceByExerciseId;
+        }
+
+        return nextPerformanceByExerciseId;
       });
     }
 
-    const nextPerformanceByExerciseId = Object.fromEntries(
-      requestedExerciseIds.map((exerciseId) => [
-        exerciseId,
-        cacheRef.current[`${currentSessionId}:${exerciseId}`] ?? null,
-      ]),
-    );
+    void hydratePreviousPerformance();
 
-    setPerformanceByExerciseId((currentPerformanceByExerciseId) => {
-      const currentKeys = Object.keys(currentPerformanceByExerciseId);
-
-      if (
-        currentKeys.length === requestedExerciseIds.length &&
-        requestedExerciseIds.every(
-          (exerciseId) =>
-            currentPerformanceByExerciseId[exerciseId] ===
-            nextPerformanceByExerciseId[exerciseId],
-        )
-      ) {
-        return currentPerformanceByExerciseId;
-      }
-
-      return nextPerformanceByExerciseId;
-    });
+    return () => {
+      isCancelled = true;
+    };
   }, [currentSessionId, db, exerciseIds, exerciseKey]);
 
   return performanceByExerciseId;

--- a/src/features/workout-mode/hooks/use-workout-starter.ts
+++ b/src/features/workout-mode/hooks/use-workout-starter.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SQLiteDatabase } from 'expo-sqlite';
 
 import { useDatabase } from '@core/database/provider';
@@ -12,7 +12,7 @@ import { generateId } from '@core/database/utils';
 import { selectNextRoutineId } from '@features/schedule';
 import {
   buildRoutineSnapshot,
-  loadRoutineExerciseTemplates,
+  loadRoutineExerciseTemplatesAsync,
 } from '@features/routines';
 import type { WorkoutSnapshotInput } from '@features/routines';
 import type { ActiveWorkoutSession } from '../types';
@@ -30,15 +30,15 @@ export interface NextRoutinePreview {
 
 interface ExerciseNameRow extends Pick<Exercise, 'id' | 'name'> {}
 
-function loadExerciseNameIndex(
-  db: Pick<SQLiteDatabase, 'getAllSync'>,
+async function loadExerciseNameIndex(
+  db: Pick<SQLiteDatabase, 'getAllAsync'>,
   exerciseIds: string[],
-): Record<string, string> {
+): Promise<Record<string, string>> {
   if (exerciseIds.length === 0) {
     return {};
   }
 
-  const exerciseRows = db.getAllSync<ExerciseNameRow>(
+  const exerciseRows = await db.getAllAsync<ExerciseNameRow>(
     `SELECT id, name
      FROM exercises
      WHERE id IN (${exerciseIds.map(() => '?').join(', ')})`,
@@ -114,8 +114,9 @@ function buildStartedWorkoutSession(
  */
 export function useWorkoutStarter(): {
   nextRoutine: NextRoutinePreview | null;
-  startWorkoutFromSchedule: () => string | null;
-  startFreeWorkout: () => string;
+  isStarting: boolean;
+  startWorkoutFromSchedule: () => Promise<string | null>;
+  startFreeWorkout: () => Promise<string>;
   refreshPreview: () => void;
 } {
   const db = useDatabase();
@@ -124,6 +125,8 @@ export function useWorkoutStarter(): {
     null,
   );
   const [refreshKey, setRefreshKey] = useState<number>(0);
+  const [isStarting, setIsStarting] = useState(false);
+  const isStartingRef = useRef(false);
 
   const refreshPreview = useCallback((): void => {
     setRefreshKey((k: number) => k + 1);
@@ -132,75 +135,21 @@ export function useWorkoutStarter(): {
   // Compute the next-routine preview from the active schedule whenever
   // the db reference or refreshKey changes.
   useEffect(() => {
-    const activeSchedule = db.getFirstSync<Schedule>(
-      'SELECT id, name, is_active, current_position FROM schedules WHERE is_active = 1 AND is_deleted = 0 LIMIT 1',
-    );
+    let isCancelled = false;
 
-    if (!activeSchedule) {
-      setNextRoutine(null);
-      return;
-    }
-
-    const entries = db.getAllSync<ScheduleEntry>(
-      'SELECT id, schedule_id, routine_id, position FROM schedule_entries WHERE schedule_id = ? ORDER BY position ASC',
-      [activeSchedule.id],
-    );
-
-    const routineId = selectNextRoutineId(
-      entries.map((e: ScheduleEntry) => ({
-        position: e.position,
-        routineId: e.routine_id,
-      })),
-      activeSchedule.current_position,
-    );
-
-    if (!routineId) {
-      setNextRoutine(null);
-      return;
-    }
-
-    const routine = db.getFirstSync<Routine>(
-      'SELECT id, name, notes FROM routines WHERE id = ? AND is_deleted = 0 LIMIT 1',
-      [routineId],
-    );
-
-    if (!routine) {
-      setNextRoutine(null);
-      return;
-    }
-
-    const routineExercises = loadRoutineExerciseTemplates(db, routineId);
-    const exerciseCount = routineExercises.length;
-    const totalSets = routineExercises.reduce(
-      (sum: number, exercise) => sum + exercise.sets.length,
-      0,
-    );
-    const estimatedMinutes = Math.max(
-      20,
-      Math.ceil((exerciseCount * 4 + totalSets * 2.5) / 5) * 5,
-    );
-
-    setNextRoutine({
-      routineId,
-      routineName: routine.name,
-      scheduleName: activeSchedule.name,
-      exerciseCount,
-      estimatedMinutes,
-    });
-  }, [db, refreshKey]);
-
-  const startWorkoutFromSchedule = useCallback((): string | null => {
-    let sessionId: string | null = null;
-    let startedSession: ActiveWorkoutSession | null = null;
-
-    db.withTransactionSync(() => {
-      // Re-fetch the active schedule inside the transaction.
-      const activeSchedule = db.getFirstSync<Schedule>(
+    async function loadPreview(): Promise<void> {
+      const activeSchedule = await db.getFirstAsync<Schedule>(
         'SELECT id, name, is_active, current_position FROM schedules WHERE is_active = 1 AND is_deleted = 0 LIMIT 1',
       );
-      if (!activeSchedule) return;
 
-      const entries = db.getAllSync<ScheduleEntry>(
+      if (!activeSchedule) {
+        if (!isCancelled) {
+          setNextRoutine(null);
+        }
+        return;
+      }
+
+      const entries = await db.getAllAsync<ScheduleEntry>(
         'SELECT id, schedule_id, routine_id, position FROM schedule_entries WHERE schedule_id = ? ORDER BY position ASC',
         [activeSchedule.id],
       );
@@ -212,155 +161,263 @@ export function useWorkoutStarter(): {
         })),
         activeSchedule.current_position,
       );
-      if (!routineId) return;
 
-      const routine = db.getFirstSync<Routine>(
+      if (!routineId) {
+        if (!isCancelled) {
+          setNextRoutine(null);
+        }
+        return;
+      }
+
+      const routine = await db.getFirstAsync<Routine>(
         'SELECT id, name, notes FROM routines WHERE id = ? AND is_deleted = 0 LIMIT 1',
         [routineId],
       );
-      if (!routine) return;
 
-      const routineExercises = loadRoutineExerciseTemplates(db, routineId);
-
-      // Build the snapshot — captures routine name + exercises at this instant.
-      const snapshot: WorkoutSnapshotInput = buildRoutineSnapshot(
-        routine.name,
-        routineExercises.map((exercise) => ({
-          exerciseId: exercise.exerciseId,
-          position: exercise.position,
-          restSeconds: exercise.restSeconds,
-          progressionPolicy: exercise.progressionPolicy,
-          targetRir: exercise.targetRir,
-          sets: exercise.sets.map((setEntry) => ({
-            position: setEntry.position,
-            targetRepsMin: setEntry.targetRepsMin,
-            targetRepsMax: setEntry.targetRepsMax,
-            plannedWeight: setEntry.plannedWeight,
-            setRole: setEntry.setRole,
-          })),
-        })),
-      );
-      const startedAt = Date.now();
-      const nextSessionId = generateId();
-      const exerciseNamesById = loadExerciseNameIndex(
-        db,
-        snapshot.exercises.map((exercise) => exercise.exerciseId),
-      );
-      const nextSession = buildStartedWorkoutSession(
-        nextSessionId,
-        startedAt,
-        snapshot,
-        exerciseNamesById,
-      );
-
-      // Create the workout session with snapshot data.
-      sessionId = nextSessionId;
-      startedSession = nextSession;
-      db.runSync(
-        'INSERT INTO workout_sessions (id, routine_id, schedule_id, snapshot_name, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)',
-        [
-          sessionId,
-          routineId,
-          activeSchedule.id,
-          snapshot.snapshotName,
-          startedAt,
-          null,
-        ],
-      );
-
-      // Eagerly create placeholder WorkoutSets from the snapshot so that
-      // routine edits cannot affect this session.
-      nextSession.exercises.forEach((exercise, exerciseIndex) => {
-        const snapshotExercise = snapshot.exercises[exerciseIndex];
-
-        if (!snapshotExercise) {
-          return;
+      if (!routine) {
+        if (!isCancelled) {
+          setNextRoutine(null);
         }
+        return;
+      }
 
-        const sessionExerciseId = generateId();
-        db.runSync(
-          `INSERT INTO workout_session_exercises (
-            id,
-            session_id,
-            exercise_id,
-            position,
-            rest_seconds,
-            progression_policy,
-            target_rir
-          ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      const routineExercises = await loadRoutineExerciseTemplatesAsync(
+        db,
+        routineId,
+      );
+      const exerciseCount = routineExercises.length;
+      const totalSets = routineExercises.reduce(
+        (sum: number, exercise) => sum + exercise.sets.length,
+        0,
+      );
+      const estimatedMinutes = Math.max(
+        20,
+        Math.ceil((exerciseCount * 4 + totalSets * 2.5) / 5) * 5,
+      );
+
+      if (!isCancelled) {
+        setNextRoutine({
+          routineId,
+          routineName: routine.name,
+          scheduleName: activeSchedule.name,
+          exerciseCount,
+          estimatedMinutes,
+        });
+      }
+    }
+
+    void loadPreview();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [db, refreshKey]);
+
+  const startWorkoutFromSchedule = useCallback(async (): Promise<
+    string | null
+  > => {
+    if (isStartingRef.current) {
+      return null;
+    }
+
+    isStartingRef.current = true;
+    setIsStarting(true);
+
+    let sessionId: string | null = null;
+    let startedSession: ActiveWorkoutSession | null = null;
+
+    try {
+      await db.withTransactionAsync(async () => {
+        // Re-fetch the active schedule inside the transaction.
+        const activeSchedule = await db.getFirstAsync<Schedule>(
+          'SELECT id, name, is_active, current_position FROM schedules WHERE is_active = 1 AND is_deleted = 0 LIMIT 1',
+        );
+        if (!activeSchedule) return;
+
+        const entries = await db.getAllAsync<ScheduleEntry>(
+          'SELECT id, schedule_id, routine_id, position FROM schedule_entries WHERE schedule_id = ? ORDER BY position ASC',
+          [activeSchedule.id],
+        );
+
+        const routineId = selectNextRoutineId(
+          entries.map((e: ScheduleEntry) => ({
+            position: e.position,
+            routineId: e.routine_id,
+          })),
+          activeSchedule.current_position,
+        );
+        if (!routineId) return;
+
+        const routine = await db.getFirstAsync<Routine>(
+          'SELECT id, name, notes FROM routines WHERE id = ? AND is_deleted = 0 LIMIT 1',
+          [routineId],
+        );
+        if (!routine) return;
+
+        const routineExercises = await loadRoutineExerciseTemplatesAsync(
+          db,
+          routineId,
+        );
+
+        // Build the snapshot — captures routine name + exercises at this instant.
+        const snapshot: WorkoutSnapshotInput = buildRoutineSnapshot(
+          routine.name,
+          routineExercises.map((exercise) => ({
+            exerciseId: exercise.exerciseId,
+            position: exercise.position,
+            restSeconds: exercise.restSeconds,
+            progressionPolicy: exercise.progressionPolicy,
+            targetRir: exercise.targetRir,
+            sets: exercise.sets.map((setEntry) => ({
+              position: setEntry.position,
+              targetRepsMin: setEntry.targetRepsMin,
+              targetRepsMax: setEntry.targetRepsMax,
+              plannedWeight: setEntry.plannedWeight,
+              setRole: setEntry.setRole,
+            })),
+          })),
+        );
+        const startedAt = Date.now();
+        const nextSessionId = generateId();
+        const exerciseNamesById = await loadExerciseNameIndex(
+          db,
+          snapshot.exercises.map((exercise) => exercise.exerciseId),
+        );
+        const nextSession = buildStartedWorkoutSession(
+          nextSessionId,
+          startedAt,
+          snapshot,
+          exerciseNamesById,
+        );
+
+        // Create the workout session with snapshot data.
+        sessionId = nextSessionId;
+        startedSession = nextSession;
+        await db.runAsync(
+          'INSERT INTO workout_sessions (id, routine_id, schedule_id, snapshot_name, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)',
           [
-            sessionExerciseId,
             sessionId,
-            exercise.exerciseId,
-            snapshotExercise.position,
-            exercise.restSeconds ?? null,
-            exercise.progressionPolicy ?? 'double_progression',
-            exercise.targetRir ?? null,
+            routineId,
+            activeSchedule.id,
+            snapshot.snapshotName,
+            startedAt,
+            null,
           ],
         );
 
-        for (const setEntry of exercise.sets) {
-          db.runSync(
-            `INSERT INTO workout_sets (
+        // Eagerly create placeholder WorkoutSets from the snapshot so that
+        // routine edits cannot affect this session.
+        for (const [
+          exerciseIndex,
+          exercise,
+        ] of nextSession.exercises.entries()) {
+          const snapshotExercise = snapshot.exercises[exerciseIndex];
+
+          if (!snapshotExercise) {
+            continue;
+          }
+
+          const sessionExerciseId = generateId();
+          await db.runAsync(
+            `INSERT INTO workout_session_exercises (
               id,
               session_id,
               exercise_id,
               position,
-              weight,
-              reps,
-              is_completed,
-              target_sets,
-              target_reps,
-              target_reps_min,
-              target_reps_max,
-              set_role
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              rest_seconds,
+              progression_policy,
+              target_rir
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
             [
-              setEntry.id,
+              sessionExerciseId,
               sessionId,
               exercise.exerciseId,
-              setEntry.position ?? 0,
-              setEntry.weight,
-              setEntry.reps,
-              0,
-              exercise.sets.length,
-              setEntry.targetRepsMin ?? null,
-              setEntry.targetRepsMin ?? null,
-              setEntry.targetRepsMax ?? null,
-              setEntry.setRole ?? 'work',
+              snapshotExercise.position,
+              exercise.restSeconds ?? null,
+              exercise.progressionPolicy ?? 'double_progression',
+              exercise.targetRir ?? null,
             ],
           );
+
+          for (const setEntry of exercise.sets) {
+            await db.runAsync(
+              `INSERT INTO workout_sets (
+                id,
+                session_id,
+                exercise_id,
+                position,
+                weight,
+                reps,
+                is_completed,
+                target_sets,
+                target_reps,
+                target_reps_min,
+                target_reps_max,
+                set_role
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              [
+                setEntry.id,
+                sessionId,
+                exercise.exerciseId,
+                setEntry.position ?? 0,
+                setEntry.weight,
+                setEntry.reps,
+                0,
+                exercise.sets.length,
+                setEntry.targetRepsMin ?? null,
+                setEntry.targetRepsMin ?? null,
+                setEntry.targetRepsMax ?? null,
+                setEntry.setRole ?? 'work',
+              ],
+            );
+          }
         }
       });
-    });
 
-    if (sessionId && startedSession) {
-      startWorkout(startedSession);
-      refreshPreview();
+      if (sessionId && startedSession) {
+        startWorkout(startedSession);
+        refreshPreview();
+      }
+
+      return sessionId;
+    } finally {
+      isStartingRef.current = false;
+      setIsStarting(false);
+    }
+  }, [db, refreshPreview, startWorkout]);
+
+  const startFreeWorkout = useCallback(async (): Promise<string> => {
+    if (isStartingRef.current) {
+      return '';
     }
 
-    return sessionId;
-  }, [db, startWorkout, refreshPreview]);
+    isStartingRef.current = true;
+    setIsStarting(true);
 
-  const startFreeWorkout = useCallback((): string => {
-    const sessionId = generateId();
-    const now = Date.now();
-    db.runSync(
-      'INSERT INTO workout_sessions (id, routine_id, schedule_id, snapshot_name, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)',
-      [sessionId, null, null, null, now, null],
-    );
-    startWorkout({
-      id: sessionId,
-      title: 'Free Workout',
-      startTime: now,
-      isFreeWorkout: true,
-      exercises: [],
-    });
-    return sessionId;
+    try {
+      const sessionId = generateId();
+      const now = Date.now();
+      await db.runAsync(
+        'INSERT INTO workout_sessions (id, routine_id, schedule_id, snapshot_name, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)',
+        [sessionId, null, null, null, now, null],
+      );
+      startWorkout({
+        id: sessionId,
+        title: 'Free Workout',
+        startTime: now,
+        isFreeWorkout: true,
+        exercises: [],
+      });
+      return sessionId;
+    } finally {
+      isStartingRef.current = false;
+      setIsStarting(false);
+    }
   }, [db, startWorkout]);
 
   return {
     nextRoutine,
+    isStarting,
     startWorkoutFromSchedule,
     startFreeWorkout,
     refreshPreview,

--- a/src/features/workout-mode/screens/workout-active-screen.tsx
+++ b/src/features/workout-mode/screens/workout-active-screen.tsx
@@ -10,7 +10,7 @@
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
-import { Alert } from 'react-native';
+import { ActivityIndicator, Alert, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { RootStackParamList } from '@core/navigation';
@@ -61,6 +61,7 @@ export function WorkoutActiveScreen({
     updateActualRir,
     toggleSetLogged,
     flushPendingWrites,
+    isCriticalMutationPending,
     completeWorkout,
     deleteWorkout,
   } = useActiveWorkoutActions();
@@ -175,14 +176,16 @@ export function WorkoutActiveScreen({
           text: 'Delete Workout',
           style: 'destructive',
           onPress: () => {
-            if (deleteWorkout()) {
-              allowExitRef.current = true;
-              if (navigation.canGoBack()) {
-                navigation.goBack();
-              } else {
-                navigation.navigate('Tabs', { screen: 'Workout' });
+            void (async () => {
+              if (await deleteWorkout()) {
+                allowExitRef.current = true;
+                if (navigation.canGoBack()) {
+                  navigation.goBack();
+                } else {
+                  navigation.navigate('Tabs', { screen: 'Workout' });
+                }
               }
-            }
+            })();
           },
         },
       ],
@@ -196,15 +199,17 @@ export function WorkoutActiveScreen({
       />
       <ActiveWorkoutContent
         onCompleteWorkout={() => {
-          flushPendingWrites();
-          const completedSessionId = completeWorkout();
+          void (async () => {
+            await flushPendingWrites();
+            const completedSessionId = await completeWorkout();
 
-          if (completedSessionId) {
-            allowExitRef.current = true;
-            navigation.replace('WorkoutSummary', {
-              sessionId: completedSessionId,
-            });
-          }
+            if (completedSessionId) {
+              allowExitRef.current = true;
+              navigation.replace('WorkoutSummary', {
+                sessionId: completedSessionId,
+              });
+            }
+          })();
         }}
         onDeleteWorkout={handleDeleteWorkout}
         onOpenExerciseDetails={(exerciseId) =>
@@ -222,6 +227,13 @@ export function WorkoutActiveScreen({
         flushPendingWrites={flushPendingWrites}
         insets={insets}
       />
+      {isCriticalMutationPending ? (
+        <View className="absolute inset-0 items-center justify-center bg-black/35">
+          <View className="rounded-2xl border border-surface-border bg-surface-card px-5 py-4">
+            <ActivityIndicator />
+          </View>
+        </View>
+      ) : null}
     </>
   );
 }

--- a/src/features/workout-mode/screens/workout-active-screen.tsx
+++ b/src/features/workout-mode/screens/workout-active-screen.tsx
@@ -177,13 +177,23 @@ export function WorkoutActiveScreen({
           style: 'destructive',
           onPress: () => {
             void (async () => {
-              if (await deleteWorkout()) {
-                allowExitRef.current = true;
-                if (navigation.canGoBack()) {
-                  navigation.goBack();
-                } else {
-                  navigation.navigate('Tabs', { screen: 'Workout' });
+              allowExitRef.current = true;
+
+              try {
+                if (!(await deleteWorkout())) {
+                  allowExitRef.current = false;
+                  return;
                 }
+              } catch (error: unknown) {
+                allowExitRef.current = false;
+                console.error('[Workout] Failed to delete workout:', error);
+                return;
+              }
+
+              if (navigation.canGoBack()) {
+                navigation.goBack();
+              } else {
+                navigation.navigate('Tabs', { screen: 'Workout' });
               }
             })();
           },
@@ -200,14 +210,22 @@ export function WorkoutActiveScreen({
       <ActiveWorkoutContent
         onCompleteWorkout={() => {
           void (async () => {
-            await flushPendingWrites();
-            const completedSessionId = await completeWorkout();
+            allowExitRef.current = true;
+            try {
+              await flushPendingWrites();
+              const completedSessionId = await completeWorkout();
 
-            if (completedSessionId) {
-              allowExitRef.current = true;
+              if (!completedSessionId) {
+                allowExitRef.current = false;
+                return;
+              }
+
               navigation.replace('WorkoutSummary', {
                 sessionId: completedSessionId,
               });
+            } catch (error: unknown) {
+              allowExitRef.current = false;
+              console.error('[Workout] Failed to complete workout:', error);
             }
           })();
         }}

--- a/src/features/workout-mode/screens/workout-home-screen.tsx
+++ b/src/features/workout-mode/screens/workout-home-screen.tsx
@@ -4,8 +4,8 @@ import {
   useFocusEffect,
 } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 import { useShallow } from 'zustand/react/shallow';
 
 import type { RootStackParamList, RootTabParamList } from '@core/navigation';
@@ -118,6 +118,7 @@ export function WorkoutHomeScreen({
   const {
     refreshPreview,
     nextRoutine,
+    isStarting,
     startWorkoutFromSchedule,
     startFreeWorkout,
   } = useWorkoutStarter();
@@ -126,7 +127,6 @@ export function WorkoutHomeScreen({
   const { allSessions, refresh: refreshHistory } = useHistoryAnalytics({
     includeSessionPage: false,
   });
-  const isStartingRef = useRef(false);
   const [dashboardNow] = useState(() => Date.now());
   const dashboardMetrics = useMemo(
     () => buildDashboardMetrics(allSessions, { now: dashboardNow }),
@@ -159,37 +159,19 @@ export function WorkoutHomeScreen({
     }, [refreshExerciseCapabilities, refreshHistory, refreshPreview]),
   );
 
-  const handleStartScheduled = (): void => {
-    if (isStartingRef.current) {
-      return;
-    }
-
-    isStartingRef.current = true;
-
-    try {
-      const sessionId = startWorkoutFromSchedule();
-      if (sessionId) {
-        navigation.navigate('ActiveWorkout');
-      }
-    } finally {
-      isStartingRef.current = false;
-    }
-  };
-
-  const handleStartFree = (): void => {
-    if (isStartingRef.current) {
-      return;
-    }
-
-    isStartingRef.current = true;
-
-    try {
-      startFreeWorkout();
+  const handleStartScheduled = useCallback(async (): Promise<void> => {
+    const sessionId = await startWorkoutFromSchedule();
+    if (sessionId) {
       navigation.navigate('ActiveWorkout');
-    } finally {
-      isStartingRef.current = false;
     }
-  };
+  }, [navigation, startWorkoutFromSchedule]);
+
+  const handleStartFree = useCallback(async (): Promise<void> => {
+    const sessionId = await startFreeWorkout();
+    if (sessionId) {
+      navigation.navigate('ActiveWorkout');
+    }
+  }, [navigation, startFreeWorkout]);
 
   const handleContinueWorkout = (): void => {
     expandWorkout();
@@ -231,11 +213,25 @@ export function WorkoutHomeScreen({
                 Continue now
               </Button>
             ) : nextRoutine ? (
-              <Button onPress={handleStartScheduled} className="w-full">
+              <Button
+                onPress={() => {
+                  void handleStartScheduled();
+                }}
+                className="w-full"
+                loading={isStarting}
+                disabled={isStarting}
+              >
                 Start now
               </Button>
             ) : (
-              <Button onPress={handleStartFree} className="w-full">
+              <Button
+                onPress={() => {
+                  void handleStartFree();
+                }}
+                className="w-full"
+                loading={isStarting}
+                disabled={isStarting}
+              >
                 Start now
               </Button>
             )}
@@ -243,8 +239,12 @@ export function WorkoutHomeScreen({
             {!hasCurrentWorkout && nextRoutine ? (
               <Button
                 accessibilityLabel="Free workout"
-                onPress={handleStartFree}
+                onPress={() => {
+                  void handleStartFree();
+                }}
                 className="mt-2 self-start px-4 py-1 button-ghost"
+                loading={isStarting}
+                disabled={isStarting}
               >
                 Free workout
               </Button>
@@ -361,6 +361,14 @@ export function WorkoutHomeScreen({
           </View>
         </View>
       </ScrollView>
+      {isStarting ? (
+        <View className="absolute inset-0 items-center justify-center bg-black/35">
+          <View className="rounded-2xl border border-surface-border bg-surface-card px-5 py-4">
+            <ActivityIndicator />
+            <Body className="mt-2 font-medium">Starting workout...</Body>
+          </View>
+        </View>
+      ) : null}
     </Container>
   );
 }

--- a/src/features/workout-mode/screens/workout-summary-screen.tsx
+++ b/src/features/workout-mode/screens/workout-summary-screen.tsx
@@ -118,12 +118,15 @@ export function WorkoutSummaryScreen({
   }, [applyTemplateUpdate, dismissedTemplatePrompt, summary?.templateUpdate]);
 
   const handleBackToHome = (): void => {
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-      return;
-    }
-
-    navigation.navigate('Tabs', { screen: 'Workout' });
+    navigation.reset({
+      index: 0,
+      routes: [
+        {
+          name: 'Tabs',
+          params: { screen: 'Workout' },
+        },
+      ],
+    });
   };
 
   if (isLoading || !summary) {

--- a/src/features/workout-mode/session-repository.ts
+++ b/src/features/workout-mode/session-repository.ts
@@ -70,22 +70,22 @@ function mergeSessionExerciseRows(
   );
 }
 
-function loadExerciseRows(
+async function loadExerciseRows(
   db: SQLiteDatabase,
   sessionId: string,
-): {
+): Promise<{
   exerciseRows: ExerciseNameRow[];
   sessionExerciseRows: WorkoutSessionExerciseRow[];
   setRows: WorkoutSetRow[];
-} {
-  const sessionExerciseRows = db.getAllSync<WorkoutSessionExerciseRow>(
+}> {
+  const sessionExerciseRows = await db.getAllAsync<WorkoutSessionExerciseRow>(
     `SELECT id, session_id, exercise_id, position, rest_seconds, progression_policy, target_rir
      FROM workout_session_exercises
      WHERE session_id = ?
      ORDER BY position ASC`,
     [sessionId],
   );
-  const setRows = db.getAllSync<WorkoutSetRow>(
+  const setRows = await db.getAllAsync<WorkoutSetRow>(
     `SELECT ws.id, ws.session_id, ws.exercise_id, ws.position, ws.weight, ws.reps, ws.is_completed, ws.target_sets, ws.target_reps, ws.target_reps_min, ws.target_reps_max, ws.actual_rir, ws.set_role
      FROM workout_sets ws
      WHERE ws.session_id = ?
@@ -103,7 +103,7 @@ function loadExerciseRows(
   const exerciseIds = orderedSessionExerciseRows.map((row) => row.exercise_id);
   const exerciseRows =
     exerciseIds.length > 0
-      ? db.getAllSync<ExerciseNameRow>(
+      ? await db.getAllAsync<ExerciseNameRow>(
           `SELECT id, name FROM exercises WHERE id IN (${exerciseIds.map(() => '?').join(', ')})`,
           exerciseIds,
         )
@@ -174,11 +174,11 @@ function buildActiveWorkoutSession(
   };
 }
 
-export function loadActiveWorkoutSession(
+export async function loadActiveWorkoutSession(
   db: SQLiteDatabase,
   sessionId: string,
-): ActiveWorkoutSession | null {
-  const sessionRow = db.getFirstSync<WorkoutSessionRow>(
+): Promise<ActiveWorkoutSession | null> {
+  const sessionRow = await db.getFirstAsync<WorkoutSessionRow>(
     'SELECT id, snapshot_name, start_time FROM workout_sessions WHERE id = ? LIMIT 1',
     [sessionId],
   );
@@ -187,7 +187,7 @@ export function loadActiveWorkoutSession(
     return null;
   }
 
-  const { exerciseRows, sessionExerciseRows, setRows } = loadExerciseRows(
+  const { exerciseRows, sessionExerciseRows, setRows } = await loadExerciseRows(
     db,
     sessionId,
   );
@@ -200,11 +200,11 @@ export function loadActiveWorkoutSession(
   );
 }
 
-export function loadInProgressWorkoutSession(
+export async function loadInProgressWorkoutSession(
   db: SQLiteDatabase,
   sessionId: string,
-): ActiveWorkoutSession | null {
-  const sessionRow = db.getFirstSync<WorkoutSessionRow>(
+): Promise<ActiveWorkoutSession | null> {
+  const sessionRow = await db.getFirstAsync<WorkoutSessionRow>(
     'SELECT id, snapshot_name, start_time FROM workout_sessions WHERE id = ? AND end_time IS NULL LIMIT 1',
     [sessionId],
   );
@@ -213,7 +213,7 @@ export function loadInProgressWorkoutSession(
     return null;
   }
 
-  const { exerciseRows, sessionExerciseRows, setRows } = loadExerciseRows(
+  const { exerciseRows, sessionExerciseRows, setRows } = await loadExerciseRows(
     db,
     sessionId,
   );
@@ -226,10 +226,10 @@ export function loadInProgressWorkoutSession(
   );
 }
 
-export function loadLatestInProgressWorkoutSession(
+export async function loadLatestInProgressWorkoutSession(
   db: SQLiteDatabase,
-): ActiveWorkoutSession | null {
-  const sessionRow = db.getFirstSync<WorkoutSessionRow>(
+): Promise<ActiveWorkoutSession | null> {
+  const sessionRow = await db.getFirstAsync<WorkoutSessionRow>(
     'SELECT id, snapshot_name, start_time FROM workout_sessions WHERE end_time IS NULL ORDER BY start_time DESC LIMIT 1',
   );
 
@@ -237,7 +237,7 @@ export function loadLatestInProgressWorkoutSession(
     return null;
   }
 
-  const { exerciseRows, sessionExerciseRows, setRows } = loadExerciseRows(
+  const { exerciseRows, sessionExerciseRows, setRows } = await loadExerciseRows(
     db,
     sessionRow.id,
   );
@@ -250,7 +250,7 @@ export function loadLatestInProgressWorkoutSession(
   );
 }
 
-export function createWorkoutSessionExerciseRecord(
+export async function createWorkoutSessionExerciseRecord(
   db: SQLiteDatabase,
   sessionId: string,
   exerciseId: string,
@@ -260,9 +260,9 @@ export function createWorkoutSessionExerciseRecord(
     WorkoutSessionExerciseRow['progression_policy']
   >,
   targetRir: number | null,
-): WorkoutSessionExerciseRow {
+): Promise<WorkoutSessionExerciseRow> {
   const sessionExerciseId = generateId();
-  db.runSync(
+  await db.runAsync(
     `INSERT INTO workout_session_exercises (
       id,
       session_id,
@@ -294,36 +294,40 @@ export function createWorkoutSessionExerciseRecord(
   };
 }
 
-export function getNextWorkoutSessionExercisePosition(
+export async function getNextWorkoutSessionExercisePosition(
   db: SQLiteDatabase,
   sessionId: string,
-): number {
+): Promise<number> {
   return (
-    (db.getFirstSync<{ max_position: number | null }>(
-      `SELECT MAX(position) AS max_position
+    ((
+      await db.getFirstAsync<{ max_position: number | null }>(
+        `SELECT MAX(position) AS max_position
        FROM workout_session_exercises
        WHERE session_id = ?`,
-      [sessionId],
+        [sessionId],
+      )
     )?.max_position ?? -1) + 1
   );
 }
 
-function getNextWorkoutSetPosition(
+async function getNextWorkoutSetPosition(
   db: SQLiteDatabase,
   sessionId: string,
   exerciseId: string,
-): number {
+): Promise<number> {
   return (
-    (db.getFirstSync<{ max_position: number | null }>(
-      `SELECT MAX(position) AS max_position
+    ((
+      await db.getFirstAsync<{ max_position: number | null }>(
+        `SELECT MAX(position) AS max_position
        FROM workout_sets
        WHERE session_id = ? AND exercise_id = ?`,
-      [sessionId, exerciseId],
+        [sessionId, exerciseId],
+      )
     )?.max_position ?? -1) + 1
   );
 }
 
-export function createWorkoutSetRecord(
+export async function createWorkoutSetRecord(
   db: SQLiteDatabase,
   sessionId: string,
   exerciseId: string,
@@ -333,11 +337,11 @@ export function createWorkoutSetRecord(
   targetRepsMin: number | null,
   targetRepsMax: number | null,
   setRole: ActiveWorkoutSet['setRole'] = 'optional',
-): ActiveWorkoutSet {
+): Promise<ActiveWorkoutSet> {
   const setId = generateId();
-  const position = getNextWorkoutSetPosition(db, sessionId, exerciseId);
+  const position = await getNextWorkoutSetPosition(db, sessionId, exerciseId);
   const targetReps = targetRepsMin;
-  db.runSync(
+  await db.runAsync(
     `INSERT INTO workout_sets (
       id,
       session_id,
@@ -385,57 +389,57 @@ export function createWorkoutSetRecord(
   };
 }
 
-export function updateWorkoutSetReps(
+export async function updateWorkoutSetReps(
   db: SQLiteDatabase,
   setId: string,
   reps: number,
-): void {
-  db.runSync(
+): Promise<void> {
+  await db.runAsync(
     'UPDATE workout_sets SET reps = ?, is_completed = 1 WHERE id = ?',
     [reps, setId],
   );
 }
 
-export function updateWorkoutSetWeight(
+export async function updateWorkoutSetWeight(
   db: SQLiteDatabase,
   setId: string,
   weight: number,
-): void {
-  db.runSync(
+): Promise<void> {
+  await db.runAsync(
     'UPDATE workout_sets SET weight = ?, is_completed = 1 WHERE id = ?',
     [weight, setId],
   );
 }
 
-export function updateWorkoutSetCompletion(
+export async function updateWorkoutSetCompletion(
   db: SQLiteDatabase,
   setId: string,
   isCompleted: boolean,
-): void {
-  db.runSync('UPDATE workout_sets SET is_completed = ? WHERE id = ?', [
+): Promise<void> {
+  await db.runAsync('UPDATE workout_sets SET is_completed = ? WHERE id = ?', [
     isCompleted ? 1 : 0,
     setId,
   ]);
 }
 
-export function updateWorkoutSetActualRir(
+export async function updateWorkoutSetActualRir(
   db: SQLiteDatabase,
   setId: string,
   actualRir: number | null,
-): void {
-  db.runSync('UPDATE workout_sets SET actual_rir = ? WHERE id = ?', [
+): Promise<void> {
+  await db.runAsync('UPDATE workout_sets SET actual_rir = ? WHERE id = ?', [
     actualRir,
     setId,
   ]);
 }
 
-export function updateWorkoutSetFields(
+export async function updateWorkoutSetFields(
   db: SQLiteDatabase,
   setId: string,
   changes: Partial<
     Pick<ActiveWorkoutSet, 'reps' | 'weight' | 'isCompleted' | 'actualRir'>
   >,
-): void {
+): Promise<void> {
   const assignments: string[] = [];
   const values: Array<number | null | string> = [];
 
@@ -463,7 +467,7 @@ export function updateWorkoutSetFields(
     return;
   }
 
-  db.runSync(
+  await db.runAsync(
     `UPDATE workout_sets
      SET ${assignments.join(', ')}
      WHERE id = ?`,
@@ -471,35 +475,35 @@ export function updateWorkoutSetFields(
   );
 }
 
-export function deleteWorkoutSetRecord(
+export async function deleteWorkoutSetRecord(
   db: SQLiteDatabase,
   setId: string,
-): void {
-  db.runSync('DELETE FROM workout_sets WHERE id = ?', [setId]);
+): Promise<void> {
+  await db.runAsync('DELETE FROM workout_sets WHERE id = ?', [setId]);
 }
 
-export function deleteWorkoutExerciseRecords(
+export async function deleteWorkoutExerciseRecords(
   db: SQLiteDatabase,
   sessionId: string,
   exerciseId: string,
-): void {
-  db.runSync(
+): Promise<void> {
+  await db.runAsync(
     'DELETE FROM workout_sets WHERE session_id = ? AND exercise_id = ?',
     [sessionId, exerciseId],
   );
-  db.runSync(
+  await db.runAsync(
     'DELETE FROM workout_session_exercises WHERE session_id = ? AND exercise_id = ?',
     [sessionId, exerciseId],
   );
 }
 
-export function updateWorkoutSessionExerciseRest(
+export async function updateWorkoutSessionExerciseRest(
   db: SQLiteDatabase,
   sessionId: string,
   exerciseId: string,
   restSeconds: number,
-): void {
-  db.runSync(
+): Promise<void> {
+  await db.runAsync(
     `UPDATE workout_session_exercises
      SET rest_seconds = ?
      WHERE session_id = ? AND exercise_id = ?`,
@@ -507,18 +511,18 @@ export function updateWorkoutSessionExerciseRest(
   );
 }
 
-export function completeWorkoutSessionRecord(
+export async function completeWorkoutSessionRecord(
   db: SQLiteDatabase,
   sessionId: string,
   endTime: number,
-): void {
-  db.withTransactionSync(() => {
-    db.runSync('UPDATE workout_sessions SET end_time = ? WHERE id = ?', [
+): Promise<void> {
+  await db.withTransactionAsync(async () => {
+    await db.runAsync('UPDATE workout_sessions SET end_time = ? WHERE id = ?', [
       endTime,
       sessionId,
     ]);
 
-    const sessionRow = db.getFirstSync<
+    const sessionRow = await db.getFirstAsync<
       Pick<WorkoutSession, 'id' | 'schedule_id'>
     >('SELECT id, schedule_id FROM workout_sessions WHERE id = ? LIMIT 1', [
       sessionId,
@@ -528,16 +532,17 @@ export function completeWorkoutSessionRecord(
       return;
     }
 
-    const schedule = db.getFirstSync<Pick<Schedule, 'id' | 'current_position'>>(
-      'SELECT id, current_position FROM schedules WHERE id = ? LIMIT 1',
-      [sessionRow.schedule_id],
-    );
+    const schedule = await db.getFirstAsync<
+      Pick<Schedule, 'id' | 'current_position'>
+    >('SELECT id, current_position FROM schedules WHERE id = ? LIMIT 1', [
+      sessionRow.schedule_id,
+    ]);
 
     if (!schedule) {
       return;
     }
 
-    const entries = db.getAllSync<Pick<ScheduleEntry, 'position'>>(
+    const entries = await db.getAllAsync<Pick<ScheduleEntry, 'position'>>(
       'SELECT position FROM schedule_entries WHERE schedule_id = ? ORDER BY position ASC',
       [sessionRow.schedule_id],
     );
@@ -551,36 +556,39 @@ export function completeWorkoutSessionRecord(
       entries.length,
     );
 
-    db.runSync('UPDATE schedules SET current_position = ? WHERE id = ?', [
-      nextCompletedPosition,
-      sessionRow.schedule_id,
-    ]);
+    await db.runAsync(
+      'UPDATE schedules SET current_position = ? WHERE id = ?',
+      [nextCompletedPosition, sessionRow.schedule_id],
+    );
   });
 }
 
-export function deleteWorkoutSessionRecord(
+export async function deleteWorkoutSessionRecord(
   db: SQLiteDatabase,
   sessionId: string,
-): void {
-  db.withTransactionSync(() => {
-    db.runSync('DELETE FROM workout_session_exercises WHERE session_id = ?', [
+): Promise<void> {
+  await db.withTransactionAsync(async () => {
+    await db.runAsync(
+      'DELETE FROM workout_session_exercises WHERE session_id = ?',
+      [sessionId],
+    );
+    await db.runAsync('DELETE FROM workout_sets WHERE session_id = ?', [
       sessionId,
     ]);
-    db.runSync('DELETE FROM workout_sets WHERE session_id = ?', [sessionId]);
-    db.runSync('DELETE FROM workout_sessions WHERE id = ?', [sessionId]);
+    await db.runAsync('DELETE FROM workout_sessions WHERE id = ?', [sessionId]);
   });
 }
 
-export function loadPreviousExercisePerformanceMap(
+export async function loadPreviousExercisePerformanceMap(
   db: SQLiteDatabase,
   currentSessionId: string,
   exerciseIds: string[],
-): Record<string, PreviousExercisePerformance | null> {
+): Promise<Record<string, PreviousExercisePerformance | null>> {
   if (exerciseIds.length === 0) {
     return {};
   }
 
-  const rows = db.getAllSync<PreviousExercisePerformanceRow>(
+  const rows = await db.getAllAsync<PreviousExercisePerformanceRow>(
     `WITH latest_completed_sessions AS (
         SELECT
           workout_sets.exercise_id,


### PR DESCRIPTION
## Summary
This PR executes **Issue #117 Phase 1 + Phase 2 (Core + Workout critical path)** and includes follow-up guidance-flicker fixes discovered during validation.

It does **not** complete the full cross-app migration track yet (Phase 3+4 items below are tracked explicitly).

Closes critical-path regressions reported during rollout:
- focused guidance flicker when switching sets
- post-completion summary/home navigation stack corruption

## Issue #117 Checklist Coverage
### Phase 1: Core platform migration
- [x] Implement async DB bootstrap and async migration runner.
  - `src/core/database/database.ts` now uses `openDatabaseAsync` and async `prepareDatabase`.
  - `src/core/database/migrations.ts` runs migrations with async DB calls and `withTransactionAsync`.
- [x] Convert seed flows to async and run outside critical first-frame path.
  - `src/core/database/seed-exercises.ts` and `src/core/database/seed-development.ts` are async.
  - `src/core/database/provider.tsx` runs seed flow during async provider bootstrap.
- [x] Provide async database context/hooks.
  - `DatabaseProvider` resolves DB asynchronously and exposes fallback UI while bootstrapping.

### Phase 2: Workout critical path first
- [x] Migrate workout starter/read/write repositories to async.
  - `src/features/workout-mode/session-repository.ts` critical reads/writes are async.
  - `src/features/workout-mode/hooks/use-workout-starter.ts` start flows are async.
  - `src/features/workout-mode/hooks/use-active-workout.ts` critical mutations are async.
- [x] Remove sync DB calls from `Start now`, active workout load, and overview-open critical path.
  - `Start now` and free-start are async + pending-protected.
  - Active session restore/load is async.
  - Workout surfaces no longer rely on sync DB calls on the critical interaction path.
- [x] Preserve optimistic state updates and queued persistence semantics.
  - Non-critical set edits remain immediate in store with queued/debounced async flush.

### Phase 3: Remaining feature hooks/repositories
- [ ] Migrate analytics/history repositories and hooks to async.
- [ ] Migrate routines/schedule repositories and hooks to async.
- [ ] Migrate profile/body-weight/goals/capabilities hooks and repositories to async.
- [ ] Migrate workout summary/template update repositories to async.

### Phase 4: Guardrails + enforcement
- [ ] Add CI gate that fails on sync DB API usage in runtime source.
- [x] Add perf contract tests for interaction responsiveness (no blocking press path).
  - Workout perf contracts updated and passing.
- [ ] Update docs with async data-loading and loading-state conventions.

## Acceptance Criteria Status (from #117)
- [ ] No runtime sync DB APIs remain in production app code.
  - Partial: Core + Workout critical path migrated; remaining sync usage exists in other features (Phase 3 backlog).
- [x] `Start now` no longer blocks navigation on DB operations.
  - Async start flow + pending/disabled controls + blocking overlay.
- [x] Opening workout overview does not trigger UI freeze.
  - Critical path avoids sync DB access; perf/behavior tests pass.
- [ ] All major routes have explicit loading/fallback UX for async fetches.
  - Partial: app bootstrap + workout critical surfaces done; other routes pending migration.
- [ ] Perf contracts pass and nightly profiling shows improvement on `start-now` and `overview-open`.
  - Local perf contracts pass in this branch; nightly benchmark deltas are not included in this PR.
- [ ] CI contains an automated sync-API regression gate.

## Additional Regression Fixes Included
During issue rollout validation, this PR also fixes:
- guidance flicker caused by programmatic WheelPicker sync events mutating guidance inputs
  - switched guidance updates to commit-only updates (settled wheel value)
  - added stale callback guards to ignore late commits after focus moves
- workout summary/home navigation race after completion/delete
  - fixed async completion/delete exit race and normalized return-home stack reset

## Validation Performed
- `npm run type-check`
- `npm run lint` (no errors; existing repository warnings remain)
- `npm test -- --runInBand src/features/workout-mode`
- push hook full suite: `54` passed

## Follow-ups (explicit)
1. Phase 3 feature migrations (analytics/routines/schedule/health/intelligence + summary/template repositories).
2. Phase 4 guardrails (CI sync-API gate + docs update).
3. Nightly perf comparison report for `start-now` and `overview-open` after this merge.
